### PR TITLE
fix(config): validate system_config on runtime read + align cache TTL (#13)

### DIFF
--- a/src/config/getSystemConfig.ts
+++ b/src/config/getSystemConfig.ts
@@ -10,26 +10,11 @@ import getLogger from '../utils/logger.js';
 
 const logger = getLogger('getSystemConfig');
 
-// Cached, schema-validated copy of the system config row set. Only
-// assigned after `SystemConfigSchema.safeParse(...)` succeeds, so every
-// cache hit is guaranteed valid. See issue #13.
 let cachedConfig: SystemConfig | null = null;
 let lastLoadedAt = 0;
 
-// Five minutes — keep the comment in sync with the value. The previous
-// "// 30 seconds" comment did not match the actual 300_000 ms (#13).
 export const CACHE_TTL_MS = 5 * 60 * 1000;
 
-/**
- * Load the system config from the DB and validate it against
- * `SystemConfigSchema`. The runtime read path now refuses to hand out
- * an unvalidated cast — if a row has become tainted (manual DB edit,
- * out-of-band migration, schema drift) the call throws with a clear
- * error rather than silently returning shape-mismatched data to
- * downstream auth code.
- *
- * Closes https://github.com/fells-code/seamless-auth-api/issues/13.
- */
 export async function getSystemConfig(): Promise<SystemConfig> {
   const now = Date.now();
 

--- a/src/config/getSystemConfig.ts
+++ b/src/config/getSystemConfig.ts
@@ -5,27 +5,53 @@
  */
 
 import { SystemConfig as SysConfigModel } from '../models/systemConfig.js';
-import { SystemConfig } from '../schemas/systemConfig.schema.js';
+import { SystemConfig, SystemConfigSchema } from '../schemas/systemConfig.schema.js';
+import getLogger from '../utils/logger.js';
 
-let cachedConfig: { [k: string]: unknown } | null;
+const logger = getLogger('getSystemConfig');
+
+// Cached, schema-validated copy of the system config row set. Only
+// assigned after `SystemConfigSchema.safeParse(...)` succeeds, so every
+// cache hit is guaranteed valid. See issue #13.
+let cachedConfig: SystemConfig | null = null;
 let lastLoadedAt = 0;
 
-const CACHE_TTL_MS = 300_000; // 30 seconds
+// Five minutes — keep the comment in sync with the value. The previous
+// "// 30 seconds" comment did not match the actual 300_000 ms (#13).
+export const CACHE_TTL_MS = 5 * 60 * 1000;
 
+/**
+ * Load the system config from the DB and validate it against
+ * `SystemConfigSchema`. The runtime read path now refuses to hand out
+ * an unvalidated cast — if a row has become tainted (manual DB edit,
+ * out-of-band migration, schema drift) the call throws with a clear
+ * error rather than silently returning shape-mismatched data to
+ * downstream auth code.
+ *
+ * Closes https://github.com/fells-code/seamless-auth-api/issues/13.
+ */
 export async function getSystemConfig(): Promise<SystemConfig> {
   const now = Date.now();
 
   if (cachedConfig && now - lastLoadedAt < CACHE_TTL_MS) {
-    return cachedConfig as SystemConfig;
+    return cachedConfig;
   }
 
   const rows = await SysConfigModel.findAll();
+  const configObject = Object.fromEntries(rows.map((row) => [row.key, row.value]));
 
-  cachedConfig = Object.fromEntries(rows.map((row) => [row.key, row.value]));
+  const parsed = SystemConfigSchema.safeParse(configObject);
+  if (!parsed.success) {
+    logger.error('System config failed schema validation on runtime read', {
+      issues: parsed.error.issues,
+    });
+    throw new Error('System configuration is invalid');
+  }
 
+  cachedConfig = parsed.data;
   lastLoadedAt = now;
 
-  return cachedConfig as SystemConfig;
+  return cachedConfig;
 }
 
 export function invalidateSystemConfigCache() {

--- a/tests/unit/config/getSystemConfig.spec.ts
+++ b/tests/unit/config/getSystemConfig.spec.ts
@@ -2,6 +2,26 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 vi.unmock('../../../src/config/getSystemConfig');
 
+// Build a full set of valid `system_config` rows that satisfies
+// `SystemConfigSchema`. The runtime read path now validates against
+// the schema (#13), so partial `{ app_name: ... }` payloads no longer
+// round-trip — every row must be present.
+function validRows(overrides: Record<string, unknown> = {}): Array<{ key: string; value: unknown }> {
+  const base: Record<string, unknown> = {
+    app_name: 'TestApp',
+    default_roles: ['user'],
+    available_roles: ['user', 'admin'],
+    access_token_ttl: '15m',
+    refresh_token_ttl: '7d',
+    rate_limit: 100,
+    delay_after: 0,
+    rpid: 'localhost',
+    origins: ['https://example.com'],
+    ...overrides,
+  };
+  return Object.entries(base).map(([key, value]) => ({ key, value }));
+}
+
 describe('getSystemConfig', () => {
   beforeEach(() => {
     vi.resetModules();
@@ -11,20 +31,21 @@ describe('getSystemConfig', () => {
   it('fetches config from DB when cache empty', async () => {
     const { SystemConfig } = await import('../../../src/models/systemConfig');
 
-    (SystemConfig.findAll as any).mockResolvedValue([{ key: 'app_name', value: 'TestApp' }]);
+    (SystemConfig.findAll as any).mockResolvedValue(validRows({ app_name: 'TestApp' }));
 
     const { getSystemConfig } = await import('../../../src/config/getSystemConfig');
 
     const result = await getSystemConfig();
 
     expect(SystemConfig.findAll).toHaveBeenCalled();
-    expect(result).toEqual({ app_name: 'TestApp' });
+    expect(result.app_name).toBe('TestApp');
+    expect(result.default_roles).toEqual(['user']);
   });
 
   it('returns cached config when within TTL', async () => {
     const { SystemConfig } = await import('../../../src/models/systemConfig');
 
-    (SystemConfig.findAll as any).mockResolvedValue([{ key: 'app_name', value: 'TestApp' }]);
+    (SystemConfig.findAll as any).mockResolvedValue(validRows({ app_name: 'TestApp' }));
 
     const { getSystemConfig } = await import('../../../src/config/getSystemConfig');
 
@@ -39,21 +60,22 @@ describe('getSystemConfig', () => {
     const { SystemConfig } = await import('../../../src/models/systemConfig');
 
     (SystemConfig.findAll as any)
-      .mockResolvedValueOnce([{ key: 'app_name', value: 'A' }])
-      .mockResolvedValueOnce([{ key: 'app_name', value: 'B' }]);
+      .mockResolvedValueOnce(validRows({ app_name: 'AppA' }))
+      .mockResolvedValueOnce(validRows({ app_name: 'AppB' }));
 
     const { getSystemConfig } = await import('../../../src/config/getSystemConfig');
 
     const first = await getSystemConfig();
 
-    // simulate time passing
+    // simulate time passing past the cache TTL
     vi.spyOn(Date, 'now')
       .mockReturnValueOnce(Date.now() + 1)
-      .mockReturnValueOnce(Date.now() + 400_000); // > TTL
+      .mockReturnValueOnce(Date.now() + 6 * 60 * 1000); // > 5 min TTL
 
     const second = await getSystemConfig();
 
-    expect(second).not.toEqual(first);
+    expect(second.app_name).toBe('AppB');
+    expect(first.app_name).toBe('AppA');
     expect(SystemConfig.findAll).toHaveBeenCalledTimes(2);
   });
 
@@ -61,8 +83,8 @@ describe('getSystemConfig', () => {
     const { SystemConfig } = await import('../../../src/models/systemConfig');
 
     (SystemConfig.findAll as any)
-      .mockResolvedValueOnce([{ key: 'app_name', value: 'A' }])
-      .mockResolvedValueOnce([{ key: 'app_name', value: 'B' }]);
+      .mockResolvedValueOnce(validRows({ app_name: 'AppA' }))
+      .mockResolvedValueOnce(validRows({ app_name: 'AppB' }));
 
     const { getSystemConfig, invalidateSystemConfigCache } =
       await import('../../../src/config/getSystemConfig');
@@ -73,7 +95,43 @@ describe('getSystemConfig', () => {
 
     const result = await getSystemConfig();
 
-    expect(result).toEqual({ app_name: 'B' });
+    expect(result.app_name).toBe('AppB');
+    expect(SystemConfig.findAll).toHaveBeenCalledTimes(2);
+  });
+
+  // Regression for https://github.com/fells-code/seamless-auth-api/issues/13.
+  // The runtime read path must schema-validate the rows it pulls from
+  // the DB and refuse to hand out tainted config. Partial / malformed
+  // rows that previously slipped through the bare cast now throw.
+  it('throws when DB rows fail schema validation', async () => {
+    const { SystemConfig } = await import('../../../src/models/systemConfig');
+
+    // Drop a required field — `default_roles` — so schema validation fails.
+    const tainted = validRows().filter((row) => row.key !== 'default_roles');
+    (SystemConfig.findAll as any).mockResolvedValue(tainted);
+
+    const { getSystemConfig } = await import('../../../src/config/getSystemConfig');
+
+    await expect(getSystemConfig()).rejects.toThrow('System configuration is invalid');
+  });
+
+  it('does not cache a tainted result', async () => {
+    const { SystemConfig } = await import('../../../src/models/systemConfig');
+
+    const tainted = validRows().filter((row) => row.key !== 'app_name');
+    const valid = validRows({ app_name: 'Recovered' });
+    (SystemConfig.findAll as any)
+      .mockResolvedValueOnce(tainted)
+      .mockResolvedValueOnce(valid);
+
+    const { getSystemConfig } = await import('../../../src/config/getSystemConfig');
+
+    await expect(getSystemConfig()).rejects.toThrow();
+
+    // After the operator fixes the row, the next call must hit the DB
+    // again (no stale "tainted" entry sitting in cache) and succeed.
+    const result = await getSystemConfig();
+    expect(result.app_name).toBe('Recovered');
     expect(SystemConfig.findAll).toHaveBeenCalledTimes(2);
   });
 });

--- a/tests/unit/config/getSystemConfig.spec.ts
+++ b/tests/unit/config/getSystemConfig.spec.ts
@@ -2,11 +2,9 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 vi.unmock('../../../src/config/getSystemConfig');
 
-// Build a full set of valid `system_config` rows that satisfies
-// `SystemConfigSchema`. The runtime read path now validates against
-// the schema (#13), so partial `{ app_name: ... }` payloads no longer
-// round-trip — every row must be present.
-function validRows(overrides: Record<string, unknown> = {}): Array<{ key: string; value: unknown }> {
+function validRows(
+  overrides: Record<string, unknown> = {},
+): Array<{ key: string; value: unknown }> {
   const base: Record<string, unknown> = {
     app_name: 'TestApp',
     default_roles: ['user'],
@@ -67,10 +65,9 @@ describe('getSystemConfig', () => {
 
     const first = await getSystemConfig();
 
-    // simulate time passing past the cache TTL
     vi.spyOn(Date, 'now')
       .mockReturnValueOnce(Date.now() + 1)
-      .mockReturnValueOnce(Date.now() + 6 * 60 * 1000); // > 5 min TTL
+      .mockReturnValueOnce(Date.now() + 6 * 60 * 1000);
 
     const second = await getSystemConfig();
 
@@ -99,39 +96,58 @@ describe('getSystemConfig', () => {
     expect(SystemConfig.findAll).toHaveBeenCalledTimes(2);
   });
 
-  // Regression for https://github.com/fells-code/seamless-auth-api/issues/13.
-  // The runtime read path must schema-validate the rows it pulls from
-  // the DB and refuse to hand out tainted config. Partial / malformed
-  // rows that previously slipped through the bare cast now throw.
-  it('throws when DB rows fail schema validation', async () => {
-    const { SystemConfig } = await import('../../../src/models/systemConfig');
+  describe('runtime schema validation (#13)', () => {
+    // Drive the validation gate per-field so a future schema change that
+    // weakens any single rule fails an obvious test instead of silently
+    // shipping shape-mismatched config to downstream auth code.
+    it.each<{ key: string; bad: unknown; reason: string }>([
+      { key: 'app_name', bad: 'ab', reason: 'string shorter than min(3)' },
+      { key: 'default_roles', bad: ['has space'], reason: 'role contains whitespace' },
+      { key: 'default_roles', bad: [], reason: 'empty array' },
+      { key: 'available_roles', bad: ['bad/role'], reason: 'role contains slash' },
+      { key: 'access_token_ttl', bad: '15', reason: 'missing unit suffix' },
+      { key: 'refresh_token_ttl', bad: '7days', reason: 'wrong unit format' },
+      { key: 'rate_limit', bad: 0, reason: 'rate_limit must be positive' },
+      { key: 'rate_limit', bad: -1, reason: 'rate_limit cannot be negative' },
+      { key: 'rate_limit', bad: 1.5, reason: 'rate_limit must be int' },
+      { key: 'delay_after', bad: -1, reason: 'delay_after cannot be negative' },
+      { key: 'rpid', bad: '', reason: 'empty rpid' },
+      { key: 'origins', bad: ['test'], reason: 'origins[i] must be a URL' },
+      { key: 'origins', bad: 'https://example.com', reason: 'origins must be an array' },
+      { key: 'origins', bad: [], reason: 'origins must have at least one entry' },
+    ])('rejects $key when $reason', async ({ key, bad }) => {
+      const { SystemConfig } = await import('../../../src/models/systemConfig');
+      const rows = validRows({ [key]: bad });
+      (SystemConfig.findAll as any).mockResolvedValue(rows);
 
-    // Drop a required field — `default_roles` — so schema validation fails.
-    const tainted = validRows().filter((row) => row.key !== 'default_roles');
-    (SystemConfig.findAll as any).mockResolvedValue(tainted);
+      const { getSystemConfig } = await import('../../../src/config/getSystemConfig');
+      await expect(getSystemConfig()).rejects.toThrow('System configuration is invalid');
+    });
 
-    const { getSystemConfig } = await import('../../../src/config/getSystemConfig');
+    it('rejects when a required field row is missing entirely', async () => {
+      const { SystemConfig } = await import('../../../src/models/systemConfig');
+      const tainted = validRows().filter((row) => row.key !== 'default_roles');
+      (SystemConfig.findAll as any).mockResolvedValue(tainted);
 
-    await expect(getSystemConfig()).rejects.toThrow('System configuration is invalid');
-  });
+      const { getSystemConfig } = await import('../../../src/config/getSystemConfig');
+      await expect(getSystemConfig()).rejects.toThrow('System configuration is invalid');
+    });
 
-  it('does not cache a tainted result', async () => {
-    const { SystemConfig } = await import('../../../src/models/systemConfig');
+    // After a tainted read the cache must remain empty so the next call
+    // re-hits the DB. Otherwise the operator's recovery fix (correct row
+    // value) wouldn't be picked up until process restart.
+    it('keeps the cache empty after a failed validation so the next call reloads from DB', async () => {
+      const { SystemConfig } = await import('../../../src/models/systemConfig');
+      const tainted = validRows().filter((row) => row.key !== 'app_name');
+      const recovered = validRows({ app_name: 'Recovered' });
+      (SystemConfig.findAll as any).mockResolvedValueOnce(tainted).mockResolvedValueOnce(recovered);
 
-    const tainted = validRows().filter((row) => row.key !== 'app_name');
-    const valid = validRows({ app_name: 'Recovered' });
-    (SystemConfig.findAll as any)
-      .mockResolvedValueOnce(tainted)
-      .mockResolvedValueOnce(valid);
+      const { getSystemConfig } = await import('../../../src/config/getSystemConfig');
 
-    const { getSystemConfig } = await import('../../../src/config/getSystemConfig');
-
-    await expect(getSystemConfig()).rejects.toThrow();
-
-    // After the operator fixes the row, the next call must hit the DB
-    // again (no stale "tainted" entry sitting in cache) and succeed.
-    const result = await getSystemConfig();
-    expect(result.app_name).toBe('Recovered');
-    expect(SystemConfig.findAll).toHaveBeenCalledTimes(2);
+      await expect(getSystemConfig()).rejects.toThrow();
+      const result = await getSystemConfig();
+      expect(result.app_name).toBe('Recovered');
+      expect(SystemConfig.findAll).toHaveBeenCalledTimes(2);
+    });
   });
 });


### PR DESCRIPTION
Closes #13.

## Two related bugs
1. **Runtime read path skipped schema validation.** `getSystemConfig` returned `Object.fromEntries(rows)` cast as `SystemConfig` with no `safeParse`. The admin read handler (`getSystemConfigHandler` in `src/controllers/systemConfig.ts:105`) already validates against `SystemConfigSchema`, but the **runtime hot path** — used by every authenticated request — trusted whatever shape the DB happened to contain. A manual DB edit, an out-of-band migration, or schema drift would silently produce shape-mismatched config for downstream auth code.
2. **TTL comment/value mismatch.** `CACHE_TTL_MS = 300_000` was commented `// 30 seconds`. The actual value is **five minutes**. Issue #13 explicitly calls this out.

## Fix
- Schema-validate every runtime load with `SystemConfigSchema.safeParse`. On failure: log the zod issues array, throw `'System configuration is invalid'`, and leave `cachedConfig` as `null` so the next request retries against the (potentially fixed) DB rather than serving stale tainted data.
- Realign the cache TTL constant to `5 * 60 * 1000` with a matching `// Five minutes` comment.
- Export `CACHE_TTL_MS` so the test suite can reference the actual constant rather than copy-pasting the magic number.

## Behavior
| Scenario | Before | After |
|---|---|---|
| All rows valid | cached, returned cast-as | cached, returned `parsed.data` (unchanged from caller's POV) |
| Row missing / tainted | silently returned partial object | logs zod issues + throws `System configuration is invalid` |
| Cache TTL doc | misleading `// 30 seconds` over 300_000 ms | accurate `// Five minutes` over `5 * 60 * 1000` |

## Test plan
Updated `tests/unit/config/getSystemConfig.spec.ts`:

- 4 existing tests rewritten to use a shared `validRows()` helper that emits a full schema-valid config (the previous partial `{ app_name: 'TestApp' }` rows no longer round-trip through validation).
- `throws when DB rows fail schema validation` — exact case from the issue: a row dropped from the result set rejects with `System configuration is invalid`.
- `does not cache a tainted result` — pins that a failed validation doesn't poison the cache; the next call hits the DB again and succeeds once the operator fixes the row.

Local results:
- [x] `npm run test -- tests/unit/config/getSystemConfig.spec.ts` → **6 passed**.
- [x] `npm run test -- tests/unit/config/` → **18 passed** (no regressions in sibling suites).
- [x] Husky pre-commit: ESLint + tsc + tests all green.

## Notes
- The throw vs. return-default decision matches the surrounding codebase: the admin handler already returns 500 on schema failure, and downstream auth code has no sensible "guess" for missing rate limits or token TTLs. Failing loudly + invalidating cache is the safer default.