### PR TITLE
docs: keep code comments minimal

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,6 +77,7 @@ Direct provider wiring currently lives in [src/config/directMessaging.ts](/Users
 - If a route also needs admin checks or rate limiting, combine `auth` with extra `middleware`.
 - Be careful around token response shapes and bearer auth. Browser-cookie auth mode has been removed.
 - Preserve existing local worktree changes unless the user explicitly asks you to clean them up.
+- Keep comments minimal. Comment only when the code genuinely needs explaining (a non-obvious reason or gotcha); do not narrate what the code plainly does.
 
 ## Before You Finish A Change
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,6 +45,8 @@ when specifically exercising real DB behavior.
   (`npm run changeset`); don't hand-edit `CHANGELOG.md` or the version in `package.json`.
 - **No `any`** (`@typescript-eslint/no-explicit-any` is an error) and imports/exports are
   auto-sorted (`simple-import-sort`).
+- **Comments** — keep them minimal. Comment only when the code genuinely needs explaining
+  (a non-obvious reason, a gotcha, an invariant). Don't narrate what the code plainly does.
 
 ### Codebase shape (where to make changes)
 


### PR DESCRIPTION
Adds a guideline to CLAUDE.md and AGENTS.md: comment only when the code genuinely needs explaining (a non-obvious reason, gotcha, or invariant), not to narrate what the code plainly does.