### PR TITLE
fix(config): make LOGIN_METHODS (and env-mapped config) authoritative over seeded defaults

### DIFF
--- a/.changeset/login-methods-env-config.md
+++ b/.changeset/login-methods-env-config.md
@@ -1,0 +1,11 @@
+---
+'seamless-auth-api': patch
+---
+
+Env-mapped system config (e.g. `LOGIN_METHODS`) now takes effect over
+migration-seeded defaults. Previously the login-policy migration hard-seeded
+`login_methods` and `bootstrapSystemConfig` only seeded missing rows, so the env
+var was permanently ignored. Now bootstrap re-applies env values over config that
+was never changed through the admin API (`updatedBy IS NULL`), admin edits record
+`updatedBy` so they are preserved, and a migration re-applies env to existing
+un-edited rows.

--- a/resources/coverage-badge.svg
+++ b/resources/coverage-badge.svg
@@ -1,5 +1,5 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="111" height="20" role="img" aria-label="coverage: 82.2%">
-  <title>coverage: 82.2%</title>
+<svg xmlns="http://www.w3.org/2000/svg" width="111" height="20" role="img" aria-label="coverage: 82.3%">
+  <title>coverage: 82.3%</title>
   <linearGradient id="smooth" x2="0" y2="100%">
     <stop offset="0" stop-color="#fff" stop-opacity=".7"/>
     <stop offset=".1" stop-color="#aaa" stop-opacity=".1"/>
@@ -17,7 +17,7 @@
   <g fill="#fff" text-anchor="middle" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" font-size="11">
     <text x="33" y="15" fill="#010101" fill-opacity=".3">coverage</text>
     <text x="33" y="14">coverage</text>
-    <text x="88.5" y="15" fill="#010101" fill-opacity=".3">82.2%</text>
-    <text x="88.5" y="14">82.2%</text>
+    <text x="88.5" y="15" fill="#010101" fill-opacity=".3">82.3%</text>
+    <text x="88.5" y="14">82.3%</text>
   </g>
 </svg>

--- a/src/config/bootstrapSystemConfig.ts
+++ b/src/config/bootstrapSystemConfig.ts
@@ -15,13 +15,31 @@ export async function bootstrapSystemConfig() {
 
   for (const [key, envVar] of Object.entries(SYSTEM_CONFIG_ENV_MAP)) {
     const existing = await SystemConfig.findByPk(key);
+    const envValue = process.env[envVar];
 
     if (existing) {
-      resolvedConfig[key] = existing.value;
+      // Re-apply the env value over config that hasn't been changed through the
+      // admin API (updatedBy IS NULL), so env-mapped config stays authoritative
+      // unless an admin has overridden it at runtime. Without this, a migration
+      // that seeds a default would permanently shadow the env var.
+      if (envValue && existing.updatedBy == null) {
+        const parsed = parseSystemConfigEnvValue(
+          key as keyof typeof SYSTEM_CONFIG_ENV_MAP,
+          envValue,
+        );
+
+        if (JSON.stringify(existing.value) !== JSON.stringify(parsed)) {
+          await existing.update({ value: parsed });
+        }
+
+        resolvedConfig[key] = parsed;
+      } else {
+        resolvedConfig[key] = existing.value;
+      }
+
       continue;
     }
 
-    const envValue = process.env[envVar];
     if (!envValue) {
       const defaultValue = SYSTEM_CONFIG_DEFAULTS[key as keyof typeof SYSTEM_CONFIG_DEFAULTS];
 

--- a/src/controllers/systemConfig.ts
+++ b/src/controllers/systemConfig.ts
@@ -73,12 +73,16 @@ export async function updateSystemConfig(req: ServiceRequest, res: Response) {
 
   const existingMap = Object.fromEntries(existingRows.map((row) => [row.key, row.value]));
 
+  const updatedBy = typeof req.clientId === 'function' ? req.clientId() : (req.clientId ?? null);
+
   await SystemConfig.sequelize!.transaction(async (tx) => {
     for (const [key, value] of Object.entries(updates)) {
       await SystemConfig.upsert(
         {
           key,
           value,
+          // Mark the row as admin-managed so bootstrap won't overwrite it from env.
+          updatedBy,
         },
         { transaction: tx },
       );

--- a/src/migrations/20260628120000-reseed-env-system-config.cjs
+++ b/src/migrations/20260628120000-reseed-env-system-config.cjs
@@ -1,0 +1,36 @@
+'use strict';
+
+// Re-apply env-mapped values over migration-seeded defaults so env vars like
+// LOGIN_METHODS take effect on existing installs. Only touches rows never changed
+// through the admin API (updatedBy IS NULL); bootstrapSystemConfig keeps them in
+// sync on every boot going forward.
+module.exports = {
+  async up(queryInterface) {
+    const loginMethods = process.env.LOGIN_METHODS;
+    if (loginMethods) {
+      const arr = loginMethods
+        .split(',')
+        .map((s) => s.trim())
+        .filter(Boolean);
+      await queryInterface.sequelize.query(
+        `UPDATE system_config SET value = CAST(:val AS jsonb), "updatedAt" = NOW()
+         WHERE key = 'login_methods' AND "updatedBy" IS NULL`,
+        { replacements: { val: JSON.stringify(arr) } },
+      );
+    }
+
+    const fallback = process.env.PASSKEY_LOGIN_FALLBACK_ENABLED;
+    if (fallback) {
+      const val = fallback.trim().toLowerCase() === 'true';
+      await queryInterface.sequelize.query(
+        `UPDATE system_config SET value = CAST(:val AS jsonb), "updatedAt" = NOW()
+         WHERE key = 'passkey_login_fallback_enabled' AND "updatedBy" IS NULL`,
+        { replacements: { val: JSON.stringify(val) } },
+      );
+    }
+  },
+
+  async down() {
+    // No-op: re-seeding from env has no meaningful inverse.
+  },
+};

--- a/tests/unit/config/bootstrapSystemConfig.spec.ts
+++ b/tests/unit/config/bootstrapSystemConfig.spec.ts
@@ -84,6 +84,48 @@ describe('bootstrapSystemConfig', () => {
     expect(result).toBeDefined();
   });
 
+  it('re-applies env over an existing row that was not admin-edited', async () => {
+    const { SystemConfig } = await import('../../../src/models/systemConfig');
+    const { parseSystemConfigEnvValue } = await import('../../../src/utils/parseEnvConfigs');
+    const { SystemConfigSchema } = await import('../../../src/schemas/systemConfig.schema');
+
+    const update = vi.fn();
+    (SystemConfig.findByPk as any).mockResolvedValue({ value: 'old', updatedBy: null, update });
+
+    process.env.APP_NAME = 'TestApp';
+    process.env.RATE_LIMIT = '100';
+    (parseSystemConfigEnvValue as any).mockReturnValue('parsed');
+    (SystemConfigSchema.safeParse as any).mockReturnValue({ success: true, data: {} });
+
+    const { bootstrapSystemConfig } = await import('../../../src/config/bootstrapSystemConfig');
+    await bootstrapSystemConfig();
+
+    expect(update).toHaveBeenCalledWith({ value: 'parsed' });
+  });
+
+  it('preserves a row that was changed via the admin API (updatedBy set)', async () => {
+    const { SystemConfig } = await import('../../../src/models/systemConfig');
+    const { parseSystemConfigEnvValue } = await import('../../../src/utils/parseEnvConfigs');
+    const { SystemConfigSchema } = await import('../../../src/schemas/systemConfig.schema');
+
+    const update = vi.fn();
+    (SystemConfig.findByPk as any).mockResolvedValue({
+      value: 'admin-value',
+      updatedBy: 'admin-id',
+      update,
+    });
+
+    process.env.APP_NAME = 'TestApp';
+    process.env.RATE_LIMIT = '100';
+    (parseSystemConfigEnvValue as any).mockReturnValue('parsed');
+    (SystemConfigSchema.safeParse as any).mockReturnValue({ success: true, data: {} });
+
+    const { bootstrapSystemConfig } = await import('../../../src/config/bootstrapSystemConfig');
+    await bootstrapSystemConfig();
+
+    expect(update).not.toHaveBeenCalled();
+  });
+
   it('throws when env missing', async () => {
     const { SystemConfig } = await import('../../../src/models/systemConfig');
 


### PR DESCRIPTION
## Problem

Closes #47. `LOGIN_METHODS` (and other `SYSTEM_CONFIG_ENV_MAP` vars) had no effect on fresh installs: migration `20260517130000` hard-seeds `login_methods`, and `bootstrapSystemConfig` only seeded **missing** rows — so the env was permanently shadowed.

## Fix (three coherent parts)

1. **`bootstrapSystemConfig`** — for env-mapped keys, re-applies the env value over an existing row **only when it was never changed through the admin API** (`updatedBy IS NULL`). Admin/runtime overrides (`updatedBy` set) are preserved. Env-mapped config is now authoritative-by-default on every boot.
2. **Admin update path** (`updateSystemConfig`) — now records `updatedBy` on upsert (it previously never set it), giving bootstrap a reliable signal to distinguish seeded defaults from admin edits.
3. **Migration `20260628120000`** — re-applies `LOGIN_METHODS` / `PASSKEY_LOGIN_FALLBACK_ENABLED` to existing un-edited rows so current installs pick up the env immediately.

## Verified

- Unit: added bootstrap tests (env re-applies over un-edited rows; admin-edited rows preserved). Full suite: 484 passing.
- **End-to-end against real Postgres**: fresh boot with `LOGIN_METHODS=passkey,magic_link,email_otp,phone_otp` now yields `login_methods = ["passkey","magic_link","email_otp","phone_otp"]` in `system_config` (was stuck at the `["passkey","magic_link"]` default).

## Note

One-time transition: installs that edited config through the admin API **before** this change have `updatedBy = NULL` (the old code never set it), so the first boot after this fix will re-apply their env values over those edits. Going forward, admin edits are marked and preserved.