### PR TITLE
ci: run seamless verify conformance on PRs

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -1,0 +1,12 @@
+# Run the cross-repo conformance matrix on PRs, testing this repo's change against
+# the rest of the ecosystem. The reusable workflow lives in seamless-cli.
+name: conformance
+
+on:
+  pull_request:
+
+jobs:
+  verify:
+    uses: fells-code/seamless-cli/.github/workflows/verify-conformance.yml@main
+    with:
+      api-ref: ${{ github.event.pull_request.head.sha }}


### PR DESCRIPTION
Adds a PR conformance check that runs the cross-repo `seamless verify` matrix (api/adapter/react) against this repos change plus the rest of the ecosystem.

Requires **fells-code/seamless-cli#19** (the reusable workflow) to be merged first; until then this PRs own conformance check cannot resolve the reusable workflow. Once #19 is on `seamless-cli` main, re-run and it goes green (validated there at 26/26).