### PR TITLE
fix(registration): rate limit the register endpoint

### DIFF
--- a/.changeset/registration-rate-limit.md
+++ b/.changeset/registration-rate-limit.md
@@ -1,0 +1,9 @@
+---
+'seamless-auth-api': patch
+---
+
+Rate limit the `POST /registration/register` endpoint.
+
+Registration now applies the same per-IP and per-identity limiters already used by
+the OTP and phone-registration routes. This closes an unthrottled path that allowed
+registration/OTP spam and account enumeration against the endpoint.

--- a/src/routes/registration.routes.ts
+++ b/src/routes/registration.routes.ts
@@ -26,6 +26,7 @@ registrationRouter.post(
   {
     summary: 'Register a new user',
     tags: ['Registration'],
+    middleware: [otpIpLimiter, otpIdentityLimiter],
 
     schemas: {
       body: RegistrationRequestSchema,


### PR DESCRIPTION
## Summary

`POST /registration/register` had no rate limiting, while every other unauthenticated credential-issuing route (OTP, magic link) and the peer `/registration/phone` route already applied limiters. This left an unthrottled path for registration/OTP spam and account enumeration against the endpoint.

This applies the existing shared limiters to the route:

- `otpIpLimiter` — 10 requests / 15 min per IP
- `otpIdentityLimiter` — 5 requests / 15 min per identity (keys on the request-body email, falls back to IP)

No new limiter code: it reuses `src/middleware/rateLimit.ts`, whose `getOtpIdentityKey` already reads `body.email`.

## Security context

Found during a security survey of the passwordless auth flows. Severity: medium. This is the only unauthenticated credential-issuing endpoint that was missing rate limiting.

## Testing

- `npm run typecheck`, `npm run lint` — clean
- Full suite via pre-commit gate: 486 passed, 3 skipped
- Registration integration tests (13) pass; the test-env limiter mock keeps them deterministic

## Notes

Behavior change: clients exceeding the limits now receive `429`. Non-contract (no route/schema/status-code changes on the success path).