### PR TITLE
feat(openapi): mark GET /logout as deprecated

### DIFF
--- a/.changeset/deprecate-get-logout-openapi.md
+++ b/.changeset/deprecate-get-logout-openapi.md
@@ -1,0 +1,10 @@
+---
+'seamless-auth-api': patch
+---
+
+Mark `GET /logout` as deprecated in the generated OpenAPI document.
+
+`defineRoute` now supports a `deprecated` flag that is forwarded to the OpenAPI
+operation. The legacy `GET /logout` route sets it, so consumers and generated
+clients can detect the deprecation and migrate to `DELETE /logout/all`. Runtime
+behavior is unchanged.

--- a/src/lib/defineRoute.ts
+++ b/src/lib/defineRoute.ts
@@ -30,6 +30,7 @@ interface DefineRouteOptions<S extends RouteSchemas> {
   summary?: string;
   description?: string;
   tags?: string[];
+  deprecated?: boolean;
 
   auth?: AuthTokenType | undefined;
 
@@ -121,7 +122,7 @@ export function defineRoute<S extends RouteSchemas>(
   router: Router,
   options: DefineRouteOptions<S>,
 ): void {
-  const { method, path, auth, schemas, summary, description, tags, handler } = options;
+  const { method, path, auth, schemas, summary, description, tags, deprecated, handler } = options;
   const authType = resolveAuthType(auth, options.middleware);
 
   const params = schemas?.params;
@@ -137,6 +138,7 @@ export function defineRoute<S extends RouteSchemas>(
     summary,
     description,
     tags,
+    deprecated,
     security: authType ? [{ [getSecuritySchemeName(authType)]: [] }] : undefined,
     request: {
       params,

--- a/src/routes/auth.routes.ts
+++ b/src/routes/auth.routes.ts
@@ -48,6 +48,7 @@ authRouter.get(
     auth: 'access',
     summary: 'Logout all sessions for the current user (deprecated; use DELETE /logout/all)',
     tags: ['Authentication'],
+    deprecated: true,
 
     schemas: {
       response: {

--- a/tests/unit/lib/defineRoute.spec.ts
+++ b/tests/unit/lib/defineRoute.spec.ts
@@ -73,6 +73,31 @@ describe('defineRoute', () => {
     );
   });
 
+  it('forwards the deprecated flag to the OpenAPI registration', async () => {
+    const { defineRoute } = await import('../../../src/lib/defineRoute');
+    const { registry } = await import('../../../src/openapi/registry');
+
+    defineRoute(Router(), {
+      method: 'get',
+      path: '/legacy',
+      deprecated: true,
+      schemas: {
+        response: {
+          200: z.object({
+            message: z.string(),
+          }),
+        },
+      },
+      handler: vi.fn(),
+    });
+
+    expect(registry.registerPath).toHaveBeenCalledWith(
+      expect.objectContaining({
+        deprecated: true,
+      }),
+    );
+  });
+
   it('runs auth middleware before custom middleware when auth is declared on the route', async () => {
     const order: string[] = [];
     const { defineRoute } = await import('../../../src/lib/defineRoute');


### PR DESCRIPTION
## Summary

`GET /logout` is described as deprecated in its summary string (superseded by `DELETE /logout/all`), but nothing in the generated OpenAPI signaled it, so SDKs and generated clients could not detect it.

This adds a `deprecated` flag to `defineRoute` that is forwarded to the OpenAPI operation, and sets it on the legacy `GET /logout` route. The flag now appears as `deprecated: true` on that operation in `/openapi.json`.

## Changes

- `src/lib/defineRoute.ts` — new optional `deprecated?: boolean` option, forwarded to `registry.registerPath`
- `src/routes/auth.routes.ts` — `deprecated: true` on `GET /logout`
- `tests/unit/lib/defineRoute.spec.ts` — asserts the flag is forwarded to the OpenAPI registration

## Notes

- Runtime behavior is unchanged; this is metadata only. The reusable `deprecated` option is available for future route deprecations.
- Patch changeset included (published OpenAPI changes).

## Testing

- `npm run typecheck`, `npm run lint` — clean
- `defineRoute` spec (5 tests) pass; verified `doc.paths['/logout'].get.deprecated === true` while `DELETE /logout` is unaffected
- Full pre-commit gate (lint, format, typecheck, coverage, build) passed