### PR TITLE
test: restore skipped connectToDb tests

### DIFF
--- a/resources/coverage-badge.svg
+++ b/resources/coverage-badge.svg
@@ -1,5 +1,5 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="111" height="20" role="img" aria-label="coverage: 82.3%">
-  <title>coverage: 82.3%</title>
+<svg xmlns="http://www.w3.org/2000/svg" width="111" height="20" role="img" aria-label="coverage: 82.5%">
+  <title>coverage: 82.5%</title>
   <linearGradient id="smooth" x2="0" y2="100%">
     <stop offset="0" stop-color="#fff" stop-opacity=".7"/>
     <stop offset=".1" stop-color="#aaa" stop-opacity=".1"/>
@@ -17,7 +17,7 @@
   <g fill="#fff" text-anchor="middle" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" font-size="11">
     <text x="33" y="15" fill="#010101" fill-opacity=".3">coverage</text>
     <text x="33" y="14">coverage</text>
-    <text x="88.5" y="15" fill="#010101" fill-opacity=".3">82.3%</text>
-    <text x="88.5" y="14">82.3%</text>
+    <text x="88.5" y="15" fill="#010101" fill-opacity=".3">82.5%</text>
+    <text x="88.5" y="14">82.5%</text>
   </g>
 </svg>

--- a/tests/integration/jwks/jwks.spec.ts
+++ b/tests/integration/jwks/jwks.spec.ts
@@ -48,35 +48,6 @@ afterAll(() => {
   vi.unstubAllEnvs();
 });
 
-describe('JWKS - Development Mode', () => {
-  // Skipped: the dev branch of jwksHandler reads ./keys/dev/public.pem from disk, which exists in
-  // a local dev checkout but not in CI (keys/ is gitignored). The fs/jose mocks configured here do
-  // not reliably reach the handler because the app is built once in beforeAll, before the per-test
-  // resetModules/env stubbing. Re-enabling this needs the harness to build the app per test (or the
-  // dev branch to be exercised without real key material). See #14.
-  it.skip('returns dev jwks', async () => {
-    vi.stubEnv('NODE_ENV', 'development');
-
-    const { readFileSync } = await import('fs');
-    const { importSPKI, exportJWK } = await import('jose');
-
-    (readFileSync as any).mockReturnValue('fake-public-key');
-
-    (importSPKI as any).mockResolvedValue('key');
-    (exportJWK as any).mockResolvedValue({
-      kty: 'RSA',
-      n: 'abc',
-      e: 'AQAB',
-    });
-
-    const res = await request(app).get('/.well-known/jwks.json');
-
-    expect(res.status).toBe(200);
-    expect(res.body.keys).toHaveLength(1);
-    expect(res.body.keys[0].kid).toBe('dev-main');
-  });
-});
-
 describe('JWKS - Production Mode', () => {
   it('returns jwks from secrets', async () => {
     vi.stubEnv('NODE_ENV', 'production');

--- a/tests/integration/jwks/jwks.spec.ts
+++ b/tests/integration/jwks/jwks.spec.ts
@@ -49,6 +49,11 @@ afterAll(() => {
 });
 
 describe('JWKS - Development Mode', () => {
+  // Skipped: the dev branch of jwksHandler reads ./keys/dev/public.pem from disk, which exists in
+  // a local dev checkout but not in CI (keys/ is gitignored). The fs/jose mocks configured here do
+  // not reliably reach the handler because the app is built once in beforeAll, before the per-test
+  // resetModules/env stubbing. Re-enabling this needs the harness to build the app per test (or the
+  // dev branch to be exercised without real key material). See #14.
   it.skip('returns dev jwks', async () => {
     vi.stubEnv('NODE_ENV', 'development');
 

--- a/tests/unit/db.spec.ts
+++ b/tests/unit/db.spec.ts
@@ -1,18 +1,17 @@
 import { vi } from 'vitest';
-vi.unmock('../src/utils/logger');
+vi.unmock('../../src/utils/logger');
 const loggerMock = {
   info: vi.fn(),
   error: vi.fn(),
 };
 
-vi.mock('../src/utils/logger', () => ({
+vi.mock('../../src/utils/logger', () => ({
   default: () => loggerMock,
 }));
 
 import { describe, it, expect, beforeEach } from 'vitest';
 
-//TODO: broken tests
-describe.skip('connectToDb', () => {
+describe('connectToDb', () => {
   beforeEach(() => {
     vi.resetModules();
     vi.clearAllMocks();


### PR DESCRIPTION
Addresses #14

## Summary

- **`tests/unit/db.spec.ts` (`connectToDb`)** was genuinely broken: the logger mock used `../src/utils/logger`, but from `tests/unit/` that resolves to `tests/src` (nonexistent), so the mock never applied and the log assertions failed. Corrected to `../../src/utils/logger` and unskipped. Both the connect-success and connect-failure cases pass, and `db.ts` (previously 0% coverage) is now exercised.

## Dev JWKS test stays skipped (with a reason)

I initially unskipped `tests/integration/jwks/jwks.spec.ts` (`returns dev jwks`) too, and it passed locally — but it **fails in CI** (`404` instead of `200`). Root cause: the dev branch of `jwksHandler` reads `./keys/dev/public.pem` from disk, which exists in a local dev checkout but not in CI (`keys/` is gitignored), and the `fs`/`jose` mocks don't reliably reach the handler because the app is built once in `beforeAll`, before the per-test `resetModules`/env stubbing. Re-enabling it needs harness rework (build the app per test, or exercise the dev branch without real key material). It's re-skipped with an inline comment explaining this.

## Testing

`db.spec.ts` + `jwks.spec.ts` pass (dev JWKS test skipped). Typecheck + lint clean.

## Note on CI

The `verify / verify` (cross-repo conformance) check fails on this PR, but it fails on **every** open PR including docs-only ones, so it is pre-existing and unrelated to this change (react harness "invalid URL" + adapter rate-limit 429s).