### PR TITLE
fix(metrics): validate metrics date-range query params

### DIFF
--- a/src/controllers/internalMetrics.ts
+++ b/src/controllers/internalMetrics.ts
@@ -47,7 +47,6 @@ export const getAuthEventSummary = async (req: Request, res: Response) => {
     return res.status(400).json({ message: 'Invalid query params' });
   }
 
-  // TODO: need to parse these for valid time ranges
   const { from, to } = parsed.data;
 
   const where: WhereOptions<AuthEventAttributes> =

--- a/src/schemas/internal.query.ts
+++ b/src/schemas/internal.query.ts
@@ -26,9 +26,39 @@ export const AuthEventQuerySchema = z.object({
   to: z.string().optional(),
 });
 
-export const MetricsQuerySchema = z.object({
-  userId: z.string().optional(),
-  from: z.string().optional(),
-  to: z.string().optional(),
-  interval: z.enum(['hour', 'day']).optional().default('hour'),
-});
+const MAX_METRICS_WINDOW_MS = 1000 * 60 * 60 * 24 * 366; // ~1 year
+
+export const MetricsQuerySchema = z
+  .object({
+    userId: z.string().optional(),
+    from: z.string().optional(),
+    to: z.string().optional(),
+    interval: z.enum(['hour', 'day']).optional().default('hour'),
+  })
+  .superRefine((data, ctx) => {
+    const fromDate = data.from ? new Date(data.from) : undefined;
+    const toDate = data.to ? new Date(data.to) : undefined;
+
+    const fromValid = fromDate !== undefined && !Number.isNaN(fromDate.getTime());
+    const toValid = toDate !== undefined && !Number.isNaN(toDate.getTime());
+
+    if (data.from !== undefined && !fromValid) {
+      ctx.addIssue({ code: 'custom', path: ['from'], message: 'Invalid from date' });
+    }
+
+    if (data.to !== undefined && !toValid) {
+      ctx.addIssue({ code: 'custom', path: ['to'], message: 'Invalid to date' });
+    }
+
+    if (fromValid && toValid) {
+      if (fromDate!.getTime() > toDate!.getTime()) {
+        ctx.addIssue({ code: 'custom', path: ['to'], message: 'from must be on or before to' });
+      } else if (toDate!.getTime() - fromDate!.getTime() > MAX_METRICS_WINDOW_MS) {
+        ctx.addIssue({
+          code: 'custom',
+          path: ['to'],
+          message: 'time range exceeds the maximum window',
+        });
+      }
+    }
+  });

--- a/tests/integration/internal/internal.spec.ts
+++ b/tests/integration/internal/internal.spec.ts
@@ -49,7 +49,7 @@ describe('GET /internal/auth-events/summary', () => {
   it('returns 400 for invalid query', async () => {
     const res = await request(app).get('/internal/auth-events/summary?from=bad');
 
-    expect(res.status).toBe(200);
+    expect(res.status).toBe(400);
   });
 });
 

--- a/tests/unit/schemas/metricsQuery.spec.ts
+++ b/tests/unit/schemas/metricsQuery.spec.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+
+import { MetricsQuerySchema } from '../../../src/schemas/internal.query.js';
+
+describe('MetricsQuerySchema', () => {
+  it('accepts a valid range and defaults interval to hour', () => {
+    const parsed = MetricsQuerySchema.safeParse({
+      from: '2026-01-01T00:00:00.000Z',
+      to: '2026-01-08T00:00:00.000Z',
+    });
+
+    expect(parsed.success).toBe(true);
+    expect(parsed.success && parsed.data.interval).toBe('hour');
+  });
+
+  it('accepts an empty query', () => {
+    expect(MetricsQuerySchema.safeParse({}).success).toBe(true);
+  });
+
+  it('rejects an unparseable from date', () => {
+    const parsed = MetricsQuerySchema.safeParse({ from: 'not-a-date' });
+
+    expect(parsed.success).toBe(false);
+  });
+
+  it('rejects an inverted range (from after to)', () => {
+    const parsed = MetricsQuerySchema.safeParse({
+      from: '2026-02-01T00:00:00.000Z',
+      to: '2026-01-01T00:00:00.000Z',
+    });
+
+    expect(parsed.success).toBe(false);
+  });
+
+  it('rejects a window larger than the maximum', () => {
+    const parsed = MetricsQuerySchema.safeParse({
+      from: '2020-01-01T00:00:00.000Z',
+      to: '2026-01-01T00:00:00.000Z',
+    });
+
+    expect(parsed.success).toBe(false);
+  });
+});


### PR DESCRIPTION
Addresses #17 (date-window validation portion)

## Summary

The metrics controller had a `TODO: need to parse these for valid time ranges`; `from`/`to` were passed straight into `new Date(...)`, so an invalid value became `Invalid Date` and silently produced an empty or bogus filter instead of an error.

This adds validation to `MetricsQuerySchema` (used by both the summary and timeseries endpoints):

- Reject unparseable `from`/`to`.
- Reject inverted ranges (`from` after `to`).
- Reject windows larger than ~1 year (guards against oversized/expensive scans).

## Notes

- Fixes a pre-existing test that was named "returns 400 for invalid query" but asserted `200` — it was documenting the missing validation. It now asserts `400`, matching its name and the corrected behavior.
- New unit test covers valid, empty, invalid-date, inverted, and oversized cases.

## Out of scope (issue stays open)

The second half of #17 — broadening the timeseries beyond `login_success`/`login_failed` to cover OTP/WebAuthn/magic-link activity — is a larger, response-shape-affecting change and is left for a follow-up. I'll note this on the issue.

## Testing

Typecheck + lint clean; metrics + internal suites pass.