### PR TITLE
refactor(refresh): remove the legacy refresh-token fallback scan

### DIFF
--- a/.changeset/refresh-fallback-telemetry.md
+++ b/.changeset/refresh-fallback-telemetry.md
@@ -1,0 +1,12 @@
+---
+'seamless-auth-api': patch
+---
+
+Remove the legacy refresh-token fallback scan.
+
+Refresh-token lookup now resolves sessions solely by their indexed `refreshTokenLookup`
+fingerprint. The compatibility path that scanned all pre-fingerprint sessions and
+bcrypt-compared each hash on a lookup miss has been removed, along with its per-request
+`Session.findAll` scan. Sessions created before the `refreshTokenLookup` migration are no
+longer refreshable and must re-authenticate; such sessions are long past the refresh-token
+TTL, so no active sessions are affected.

--- a/src/controllers/authentication.ts
+++ b/src/controllers/authentication.ts
@@ -284,16 +284,13 @@ export const refreshSession = async (req: Request, res: Response) => {
   }
 
   const now = new Date();
-  const { session, legacyFallbackCandidates, usedLegacyFallback } = await findRefreshSessionByToken(
-    refreshToken,
-    now,
-  );
+  const session = await findRefreshSessionByToken(refreshToken, now);
 
   if (!session) {
     const looksLikeJwt = refreshToken.split('.').length === 3;
 
     logger.warn(
-      `No refresh session found for refresh token. legacyFallbackCandidates=${legacyFallbackCandidates} tokenFormat=${looksLikeJwt ? 'jwt_like' : 'opaque'}`,
+      `No refresh session found for refresh token. tokenFormat=${looksLikeJwt ? 'jwt_like' : 'opaque'}`,
     );
 
     if (looksLikeJwt) {
@@ -304,16 +301,9 @@ export const refreshSession = async (req: Request, res: Response) => {
 
     await AuthEventService.refreshTokenFailed(req, {
       reason: 'No refresh session found for refresh token',
-      legacyFallbackCandidates,
       tokenFormat: looksLikeJwt ? 'jwt_like' : 'opaque',
     });
     return res.status(401).json({ error: 'invalid_refresh_token' });
-  }
-
-  if (usedLegacyFallback) {
-    logger.info(
-      `Refresh token matched a legacy session without refreshTokenLookup. sessionId=${session.id} fallbackCandidates=${legacyFallbackCandidates}`,
-    );
   }
 
   // Reuse detection: if this session was already rotated, it means we’ve seen this token before

--- a/src/services/sessionService.ts
+++ b/src/services/sessionService.ts
@@ -4,7 +4,6 @@
  * See LICENSE file in the project root for full license information
  */
 
-import { compareSync } from 'bcrypt-ts';
 import { importSPKI, jwtVerify } from 'jose';
 import { Op } from 'sequelize';
 
@@ -116,60 +115,20 @@ export async function validateAccessToken(token: string): Promise<ValidatedAcces
   };
 }
 
-export interface RefreshSessionLookupResult {
-  session: Session | null;
-  legacyFallbackCandidates: number;
-  usedLegacyFallback: boolean;
-}
-
 export async function findRefreshSessionByToken(
   refreshToken: string,
   now = new Date(),
-): Promise<RefreshSessionLookupResult> {
-  const activeWhere = {
-    revokedAt: null,
-    expiresAt: { [Op.gt]: now },
-    idleExpiresAt: { [Op.gt]: now },
-  };
-
+): Promise<Session | null> {
   const refreshTokenLookup = createRefreshTokenLookup(refreshToken);
-  const session = await Session.findOne({
+
+  return Session.findOne({
     where: {
-      ...activeWhere,
+      revokedAt: null,
+      expiresAt: { [Op.gt]: now },
+      idleExpiresAt: { [Op.gt]: now },
       refreshTokenLookup,
     },
   });
-
-  if (session) {
-    return {
-      session,
-      legacyFallbackCandidates: 0,
-      usedLegacyFallback: false,
-    };
-  }
-
-  const legacySessions = await Session.findAll({
-    where: {
-      ...activeWhere,
-      refreshTokenLookup: null,
-    },
-  });
-
-  for (const legacySession of legacySessions) {
-    if (compareSync(refreshToken, legacySession.refreshTokenHash)) {
-      return {
-        session: legacySession,
-        legacyFallbackCandidates: legacySessions.length,
-        usedLegacyFallback: true,
-      };
-    }
-  }
-
-  return {
-    session: null,
-    legacyFallbackCandidates: legacySessions.length,
-    usedLegacyFallback: legacySessions.length > 0,
-  };
 }
 
 export async function validateSessionRecord(sessionId: string) {

--- a/tests/e2e/authFlow.spec.ts
+++ b/tests/e2e/authFlow.spec.ts
@@ -126,11 +126,7 @@ describe('E2E Auth Flow', () => {
 
     (validateAccessToken as any).mockResolvedValue(null);
     (validateBearerToken as any).mockResolvedValue(null);
-    (findRefreshSessionByToken as any).mockResolvedValue({
-      session: buildSession(),
-      legacyFallbackCandidates: 0,
-      usedLegacyFallback: false,
-    });
+    (findRefreshSessionByToken as any).mockResolvedValue(buildSession());
 
     (User.findByPk as any).mockResolvedValue({
       id: 'user-1',

--- a/tests/integration/authentication/authentication.spec.ts
+++ b/tests/integration/authentication/authentication.spec.ts
@@ -204,11 +204,7 @@ describe('POST /refresh', () => {
   });
 
   it('rejects invalid session', async () => {
-    (findRefreshSessionByToken as any).mockResolvedValue({
-      session: null,
-      legacyFallbackCandidates: 0,
-      usedLegacyFallback: false,
-    });
+    (findRefreshSessionByToken as any).mockResolvedValue(null);
 
     const res = await request(app).post('/refresh').set('Authorization', 'Bearer refresh-token');
 
@@ -228,11 +224,7 @@ describe('POST /refresh', () => {
       save: vi.fn(),
     };
 
-    (findRefreshSessionByToken as any).mockResolvedValue({
-      session,
-      legacyFallbackCandidates: 0,
-      usedLegacyFallback: false,
-    });
+    (findRefreshSessionByToken as any).mockResolvedValue(session);
 
     (User.findByPk as any).mockResolvedValue(buildUser());
 

--- a/tests/unit/controllers/authentication.spec.ts
+++ b/tests/unit/controllers/authentication.spec.ts
@@ -85,11 +85,7 @@ describe('refreshSession', () => {
       await loadAuthenticationModule();
     const { req, res } = mockReqRes('Bearer raw-refresh-token');
 
-    (findRefreshSessionByToken as any).mockResolvedValue({
-      session: null,
-      legacyFallbackCandidates: 2,
-      usedLegacyFallback: true,
-    });
+    (findRefreshSessionByToken as any).mockResolvedValue(null);
     (AuthEventService.refreshTokenFailed as any).mockResolvedValue(undefined);
 
     await refreshSession(req, res);
@@ -99,7 +95,6 @@ describe('refreshSession', () => {
       req,
       expect.objectContaining({
         reason: 'No refresh session found for refresh token',
-        legacyFallbackCandidates: 2,
         tokenFormat: 'opaque',
       }),
     );
@@ -133,11 +128,7 @@ describe('refreshSession', () => {
       save: vi.fn(),
     };
 
-    (findRefreshSessionByToken as any).mockResolvedValue({
-      session,
-      legacyFallbackCandidates: 0,
-      usedLegacyFallback: false,
-    });
+    (findRefreshSessionByToken as any).mockResolvedValue(session);
     (User.findByPk as any).mockResolvedValue(user);
     (generateRefreshToken as any).mockReturnValue('new-raw-refresh-token');
     (hashRefreshToken as any).mockResolvedValue('new-refresh-hash');

--- a/tests/unit/services/sessionService.spec.ts
+++ b/tests/unit/services/sessionService.spec.ts
@@ -175,7 +175,7 @@ describe('sessionService', () => {
     expect(result).toBe(session);
   });
 
-  it('finds refresh sessions by indexed lookup before falling back to bcrypt comparison', async () => {
+  it('finds a refresh session by its indexed lookup fingerprint', async () => {
     const { Session } = await import('../../../src/models/sessions');
     const { createRefreshTokenLookup } = await import('../../../src/lib/token');
 
@@ -195,63 +195,21 @@ describe('sessionService', () => {
         }),
       }),
     );
-    expect(result).toEqual({
-      session,
-      legacyFallbackCandidates: 0,
-      usedLegacyFallback: false,
-    });
+    expect(result).toBe(session);
   });
 
-  it('falls back to legacy refresh-token hashes for sessions without lookup fingerprints', async () => {
+  it('returns null when no session matches the lookup fingerprint', async () => {
     const { Session } = await import('../../../src/models/sessions');
     const { createRefreshTokenLookup } = await import('../../../src/lib/token');
-    const { compareSync } = await import('bcrypt-ts');
-
-    const legacySession = buildSession({ refreshTokenHash: 'legacy-hash' });
 
     (createRefreshTokenLookup as any).mockReturnValue('lookup');
     (Session.findOne as any).mockResolvedValue(null);
-    (Session.findAll as any).mockResolvedValue([legacySession]);
-    (compareSync as any).mockReturnValue(true);
 
     const { findRefreshSessionByToken } = await import('../../../src/services/sessionService');
 
     const result = await findRefreshSessionByToken('refresh-token');
 
-    expect(Session.findAll).toHaveBeenCalledWith(
-      expect.objectContaining({
-        where: expect.objectContaining({
-          refreshTokenLookup: null,
-        }),
-      }),
-    );
-    expect(compareSync).toHaveBeenCalledWith('refresh-token', 'legacy-hash');
-    expect(result).toEqual({
-      session: legacySession,
-      legacyFallbackCandidates: 1,
-      usedLegacyFallback: true,
-    });
-  });
-
-  it('returns a legacy fallback miss when no legacy session hash matches', async () => {
-    const { Session } = await import('../../../src/models/sessions');
-    const { createRefreshTokenLookup } = await import('../../../src/lib/token');
-    const { compareSync } = await import('bcrypt-ts');
-
-    (createRefreshTokenLookup as any).mockReturnValue('lookup');
-    (Session.findOne as any).mockResolvedValue(null);
-    (Session.findAll as any).mockResolvedValue([buildSession({ refreshTokenHash: 'legacy-hash' })]);
-    (compareSync as any).mockReturnValue(false);
-
-    const { findRefreshSessionByToken } = await import('../../../src/services/sessionService');
-
-    const result = await findRefreshSessionByToken('refresh-token');
-
-    expect(result).toEqual({
-      session: null,
-      legacyFallbackCandidates: 1,
-      usedLegacyFallback: true,
-    });
+    expect(result).toBeNull();
   });
 
   it('revokes replaced sessions during validateSessionRecord', async () => {


### PR DESCRIPTION
Closes #18

## Summary

Removes the legacy refresh-token fallback scan entirely (superseding the earlier telemetry approach).

`findRefreshSessionByToken` now resolves a session **solely by its indexed `refreshTokenLookup` fingerprint** and returns `Session | null`. The compatibility path that, on a lookup miss, loaded every pre-fingerprint session (`Session.findAll({ refreshTokenLookup: null })`) and `bcrypt`-compared each hash is gone, along with the `RefreshSessionLookupResult` wrapper and the now-unused `compareSync` import.

## Why now

The `refreshTokenLookup` column was added months ago (migration `20260423150000-add-refresh-token-lookup`). Any session created before it is far past the refresh-token TTL (1h by default), so no active session relies on the fallback. Removing it drops a full-table `Session.findAll` + per-row bcrypt on every lookup miss.

## Behavior change

Sessions created before the `refreshTokenLookup` migration are no longer refreshable and must re-authenticate. As above, none should be active. The `/refresh` response shape and success path are unchanged.

## Changes

- `src/services/sessionService.ts` — simplify `findRefreshSessionByToken` to the indexed lookup; return `Session | null`; drop the interface and `compareSync` import.
- `src/controllers/authentication.ts` — consume the plain session; remove the `usedLegacyFallback` / `legacyFallbackCandidates` handling.
- Tests (unit/integration/e2e) updated to the new return type; the legacy-scan tests are removed and replaced with lookup hit/miss coverage.

## Testing

Typecheck + lint clean; full suite green (495 passed). Rebased onto current `main`.