### PR TITLE
chore(admin): remove stale session-DTO TODO

### DIFF
--- a/src/controllers/admin.ts
+++ b/src/controllers/admin.ts
@@ -323,7 +323,6 @@ export const getUserAnomalies = async (req: Request, res: Response) => {
   }
 };
 
-// TODO: Need a public session return type for sessions
 export const listUserSessions = async (req: Request, res: Response) => {
   const { userId } = req.params;
 


### PR DESCRIPTION
Closes #16

## Summary

#16 asked for a reusable public session DTO for the admin APIs (session shaping was duplicated with a TODO). That refactor is already in place:

- `serializeSession` (`src/services/apiResponseSerializers.ts`) is the shared mapper, used by `getUserDetail`, `listUserSessions`, and `listAllSessions`.
- The public schema is `SessionSchema` / `SessionListResponseSchema` (`src/schemas/session.responses.ts`), and the admin session routes declare it as their `200` response, so responses are validated.

The only remnant was a stale `// TODO: Need a public session return type for sessions` comment above `listUserSessions`. This removes it. No behavior change.

## Testing

Lint + typecheck clean.