### PR TITLE
ci: mirror released auth image to ECR

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -50,3 +50,45 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           platforms: linux/amd64,linux/arm64
+
+  # Mirror the released multi-arch image into ECR so the serverless trial and
+  # hybrid runners can pull it. Requires repo variables ECR_PUBLISH_ROLE_ARN,
+  # ECR_AWS_REGION, ECR_REGISTRY, and ECR_REPOSITORY, and an OIDC role that
+  # trusts this repository and can push to that ECR repository.
+  publish-to-ecr:
+    needs: build-and-publish
+    runs-on: ubuntu-latest
+    if: vars.ECR_PUBLISH_ROLE_ARN != ''
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ vars.ECR_PUBLISH_ROLE_ARN }}
+          aws-region: ${{ vars.ECR_AWS_REGION }}
+
+      - name: Log in to Amazon ECR
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Mirror release tag from ghcr to ECR
+        env:
+          SOURCE_IMAGE: ghcr.io/${{ env.IMAGE_NAME }}
+          ECR_IMAGE: ${{ vars.ECR_REGISTRY }}/${{ vars.ECR_REPOSITORY }}
+          TAG: ${{ github.ref_name }}
+        run: |
+          docker buildx imagetools create \
+            --tag "${ECR_IMAGE}:${TAG}" \
+            --tag "${ECR_IMAGE}:latest" \
+            "${SOURCE_IMAGE}:${TAG}"


### PR DESCRIPTION
## Summary

The serverless trial and hybrid runners pull the tenant auth image from ECR
(`fellscode/seamless-auth`), but the release workflow only published to ghcr, so
ECR fell behind (it was stuck at v0.1.5 while releases had reached v0.2.5). This
forced a manual mirror during the trial GA validation.

Add a `publish-to-ecr` job that mirrors each released multi-arch tag from ghcr
into ECR after the ghcr publish, using GitHub OIDC. It is gated on the ECR
publish variables being configured, so it is a no op until they are set.

## Configuration required

Set these repository variables and provision an OIDC role that trusts this
repository and can push to the ECR repository:

- `ECR_PUBLISH_ROLE_ARN`
- `ECR_AWS_REGION`
- `ECR_REGISTRY`
- `ECR_REPOSITORY`
