### PR TITLE
fix: store null phone for OAuth-created users

### DIFF
--- a/.changeset/oauth-null-phone.md
+++ b/.changeset/oauth-null-phone.md
@@ -1,0 +1,5 @@
+---
+'seamless-auth-api': patch
+---
+
+Fix OAuth signup writing a synthetic `oauth:<provider>:<subject>` string into the user's phone field. New OAuth users now have a null phone since the provider supplies no phone number.

--- a/resources/coverage-badge.svg
+++ b/resources/coverage-badge.svg
@@ -1,5 +1,5 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="111" height="20" role="img" aria-label="coverage: 82.5%">
-  <title>coverage: 82.5%</title>
+<svg xmlns="http://www.w3.org/2000/svg" width="111" height="20" role="img" aria-label="coverage: 82.6%">
+  <title>coverage: 82.6%</title>
   <linearGradient id="smooth" x2="0" y2="100%">
     <stop offset="0" stop-color="#fff" stop-opacity=".7"/>
     <stop offset=".1" stop-color="#aaa" stop-opacity=".1"/>
@@ -17,7 +17,7 @@
   <g fill="#fff" text-anchor="middle" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" font-size="11">
     <text x="33" y="15" fill="#010101" fill-opacity=".3">coverage</text>
     <text x="33" y="14">coverage</text>
-    <text x="88.5" y="15" fill="#010101" fill-opacity=".3">82.5%</text>
-    <text x="88.5" y="14">82.5%</text>
+    <text x="88.5" y="15" fill="#010101" fill-opacity=".3">82.6%</text>
+    <text x="88.5" y="14">82.6%</text>
   </g>
 </svg>

--- a/src/services/oauthService.ts
+++ b/src/services/oauthService.ts
@@ -435,7 +435,7 @@ export async function resolveOAuthUser(provider: OAuthProviderConfig, profile: O
 
     user = await User.create({
       email: profile.email,
-      phone: `oauth:${provider.id}:${profile.subject}`.slice(0, 255),
+      phone: null,
       roles: config.default_roles ?? [],
       verified: true,
       emailVerified: profile.emailVerified ?? true,

--- a/tests/integration/oauth/oauth.spec.ts
+++ b/tests/integration/oauth/oauth.spec.ts
@@ -122,7 +122,7 @@ describe('OAuth routes', () => {
     const user = buildUser({
       id: 'user-1',
       email: 'person@example.com',
-      phone: 'oauth:google:provider-user',
+      phone: null,
       roles: ['user'],
     });
     const fetchMock = vi.fn();

--- a/tests/unit/services/oauthService.spec.ts
+++ b/tests/unit/services/oauthService.spec.ts
@@ -243,6 +243,32 @@ describe('oauthService', () => {
     );
   });
 
+  it('creates a new user with a null phone when no existing account matches', async () => {
+    const created = buildUser({ id: 'user-2', email: 'new@example.com', phone: null });
+
+    (OAuthIdentity.findOne as any).mockResolvedValue(null);
+    (User.findOne as any).mockResolvedValue(null);
+    (User.create as any).mockResolvedValue(created);
+    (OAuthIdentity.findOrCreate as any).mockResolvedValue([]);
+
+    await expect(
+      resolveOAuthUser(provider, {
+        subject: 'provider-user',
+        email: 'new@example.com',
+        emailVerified: true,
+        name: 'New Person',
+        raw: {},
+      }),
+    ).resolves.toBe(created);
+
+    expect(User.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        email: 'new@example.com',
+        phone: null,
+      }),
+    );
+  });
+
   it('does not link an OAuth profile to an existing user when account linking is disabled', async () => {
     const user = buildUser({ id: 'user-1', email: 'person@example.com' });
 


### PR DESCRIPTION
## Problem

OAuth signup wrote a synthetic identifier into the user's phone field:

```ts
phone: `oauth:${provider.id}:${profile.subject}`.slice(0, 255),
```

So an OAuth signup produced `phone = "oauth:google:1234567890"` rather than an actual phone number. Providers supply no phone number, so this polluted the phone column (which is unique and nullable) with a non-phone value.

## Fix

- `resolveOAuthUser` now creates OAuth users with `phone: null`. The column is already nullable, and Postgres allows multiple NULLs under a unique constraint.
- Added a unit test covering the OAuth signup branch (previously uncovered), asserting `User.create` is called with `phone: null`.
- Updated the integration test fixture that had baked in the buggy value.

## Checks

- `npm run typecheck` clean
- `npm run lint` clean
- OAuth unit + integration tests pass (19 tests)

## Notes

Existing records already created with an `oauth:...` phone are not touched by this change (new signups only).