### PR TITLE
docs: retire starter repos in favor of seamless-templates

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,10 +81,10 @@ This API also **consumes** `@seamless-auth/types` (shared Zod schemas) and
 token claims), `seamless-auth-react` (client SDK — ~38 hardcoded routes, parses `message`/user
 shape), `seamless-auth-types` (shared schemas — bidirectional), `seamless-messaging` (adapter
 contract — bidirectional).
-**Downstream (Tier 2):** `seamless-auth-admin-dashboard`, `seamless-auth-starter-express`,
-`seamless-auth-starter-react`, `seamless-auth-internal-api`, `seamless-auth-docs`, `seamless-cli`.
+**Downstream (Tier 2):** `seamless-auth-admin-dashboard`, `seamless-templates`,
+`seamless-auth-internal-api`, `seamless-auth-docs`, `seamless-cli`.
 
-All ten are granted in `.claude/settings.local.json` so I can read/edit them.
+All nine are granted in `.claude/settings.local.json` so I can read/edit them.
 
 ### Ripple protocol — when a change here touches the contract
 

--- a/docs/ecosystem.md
+++ b/docs/ecosystem.md
@@ -96,14 +96,13 @@ Provider-agnostic email/SMS adapter contract. **Reverse coupling.**
 
 ## Tier 2 — downstream consumers (transitively affected)
 
-| Repo                               | What it is                      | Coupling                                                                                         |
-| ---------------------------------- | ------------------------------- | ------------------------------------------------------------------------------------------------ |
-| `seamless-auth-admin-dashboard`    | Admin UI                        | `@seamless-auth/react` + `@seamless-auth/types`; consumes `/admin/*` + `/internal/*` via the SDK |
-| `seamless-auth-starter-express`    | Express starter/demo            | `@seamless-auth/express` — breaks only if the server adapter's public API changes                |
-| `seamless-auth-starter-react`      | React starter/demo              | `@seamless-auth/react` — same, via the client SDK                                                |
-| `seamless-auth-internal-api`       | Internal/enterprise API variant | Tracks this codebase closely; likely needs parallel changes for shared logic                     |
-| `seamless-auth-docs`               | Public docs                     | Documents the HTTP contract — update when routes/schemas change                                  |
-| `seamless-cli` (`create-seamless`) | Scaffolding CLI                 | Generates projects wired to the SDKs                                                             |
+| Repo                               | What it is                                                | Coupling                                                                                         |
+| ---------------------------------- | --------------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
+| `seamless-auth-admin-dashboard`    | Admin UI                                                  | `@seamless-auth/react` + `@seamless-auth/types`; consumes `/admin/*` + `/internal/*` via the SDK |
+| `seamless-templates`               | Express + React starter templates (scaffolded by the CLI) | `@seamless-auth/express` and `@seamless-auth/react`; break only if those SDK public APIs change  |
+| `seamless-auth-internal-api`       | Internal/enterprise API variant                           | Tracks this codebase closely; likely needs parallel changes for shared logic                     |
+| `seamless-auth-docs`               | Public docs                                               | Documents the HTTP contract — update when routes/schemas change                                  |
+| `seamless-cli` (`create-seamless`) | Scaffolding CLI                                           | Generates projects wired to the SDKs                                                             |
 
 ## High-risk contract surfaces (change = survey downstream)
 


### PR DESCRIPTION
The `seamless-auth-starter-express` and `seamless-auth-starter-react` repos are archived; their starters now live in the `seamless-templates` monorepo and are scaffolded by the CLI. Update the ecosystem docs and CLAUDE.md downstream list to reference `seamless-templates` instead of the two retired repos.