### PR TITLE
fix: return controller response unchanged when it fails its schema

### DIFF
--- a/.changeset/defineroute-response-passthrough.md
+++ b/.changeset/defineroute-response-passthrough.md
@@ -1,0 +1,5 @@
+---
+'seamless-auth-api': patch
+---
+
+Fix response schema handling so a controller response that fails its declared schema is no longer overwritten. Previously the API replaced the real body with a generic `Response validation failed` object and leaked internal Zod issues to clients. It now logs the drift server-side and returns the controller's intended response unchanged.

--- a/src/lib/defineRoute.ts
+++ b/src/lib/defineRoute.ts
@@ -198,12 +198,17 @@ export function defineRoute<S extends RouteSchemas>(
 
             return originalJson(data);
           } catch (err) {
-            logger.error('Response schema validation failed', err);
-
-            return originalJson({
-              error: 'Response validation failed',
+            // A response that violates its own schema is a server-side drift bug. Log it
+            // for observability, but do not overwrite the controller's response or leak
+            // internal schema issues to the client: the handler's payload is the source of
+            // truth for the client contract.
+            logger.error('Response schema validation failed', {
+              path,
+              status: res.statusCode,
               issues: err instanceof ZodError ? err.issues : err,
             });
+
+            return originalJson(data);
           }
         }) as typeof res.json;
       }

--- a/tests/unit/lib/defineRoute.spec.ts
+++ b/tests/unit/lib/defineRoute.spec.ts
@@ -343,7 +343,7 @@ describe('defineRoute', () => {
     expect(json).toHaveBeenCalledWith({ error: 'not found' });
   });
 
-  it('returns a validation error body when the response fails its schema', async () => {
+  it('returns the original response body unchanged when it fails its schema', async () => {
     const { defineRoute } = await import('../../../src/lib/defineRoute');
     const router = Router();
 
@@ -361,11 +361,9 @@ describe('defineRoute', () => {
     const { res, json } = makeRes();
     await runRoute(router, '/bad-response', res);
 
-    expect(json).toHaveBeenCalledWith(
-      expect.objectContaining({
-        error: 'Response validation failed',
-        issues: expect.any(Array),
-      }),
+    expect(json).toHaveBeenCalledWith({ message: 123 });
+    expect(json).not.toHaveBeenCalledWith(
+      expect.objectContaining({ error: 'Response validation failed' }),
     );
   });
 
@@ -448,7 +446,7 @@ describe('defineRoute', () => {
     expect(json).toHaveBeenCalledWith({ message: 'ok' });
   });
 
-  it('surfaces the raw error when response validation throws a non-Zod error', async () => {
+  it('returns the original body when response validation throws a non-Zod error', async () => {
     const { defineRoute } = await import('../../../src/lib/defineRoute');
     const router = Router();
     const failure = new Error('non-zod failure');
@@ -473,10 +471,7 @@ describe('defineRoute', () => {
     const { res, json } = makeRes();
     await runRoute(router, '/non-zod-response', res);
 
-    expect(json).toHaveBeenCalledWith({
-      error: 'Response validation failed',
-      issues: failure,
-    });
+    expect(json).toHaveBeenCalledWith({ message: 'ok' });
   });
 
   it('parses and replaces params and query when their schemas are provided', async () => {


### PR DESCRIPTION
## Summary

`defineRoute` wraps `res.json` to validate each response against its declared response schema. On a validation failure it replaced the real body with `{ error: 'Response validation failed', issues: [...] }` while keeping the original status code. That has two problems:

1. **The real error is hidden** from the client (e.g. the login email-lookup path returns `res.status(401).json({ message: 'Not allowed' })`, but `ErrorSchema` requires `error`, so the client got the generic body instead).
2. **Internal Zod `issues` leak** to API clients, exposing schema structure.

This changes the failure path to log the drift server-side (path, status, issues) and return the controller's intended payload unchanged. The success path (schema stripping of unknown keys) is unchanged.

## Why pass-through

The controller is the source of truth for the client contract. Response-schema validation is best used as a logged drift detector plus OpenAPI documentation, not as something that silently rewrites live responses or leaks internals. Failing open returns the real, useful error to clients.

## Contract impact (ripple protocol)

Contract-affecting: on response-schema-drift paths, clients now receive the controller's real body instead of the generic `Response validation failed` object. Surveyed the Tier 1 dependents (`seamless-auth-server`, `seamless-auth-react`, `seamless-auth-types`): none reference `Response validation failed` or parse `.issues` on error responses, so blast radius is nil and the change only makes responses more correct. Changeset included (patch).

## Follow-up (not in this PR)

A few controllers still return `{ message }` on error statuses whose schema declares `{ error }` (documentation drift, now visible in logs rather than corrupting responses). Worth reconciling controllers and schemas separately.

## Verification

`npm run typecheck`, `npm run lint`, `npm run format:check`, `npm run coverage` all pass. Added a defineRoute unit test asserting the original payload is returned and no `issues` leak on schema mismatch.