### PR TITLE
fix: bind aud claim on signed user tokens

### DIFF
--- a/.changeset/set-token-audience.md
+++ b/.changeset/set-token-audience.md
@@ -1,0 +1,5 @@
+---
+'seamless-auth-api': patch
+---
+
+Bind the `aud` claim on signed user tokens. `signAccessToken`, `signRefreshToken`, and `signEphemeralToken` now call `.setAudience(ISSUER)` in addition to `.setIssuer(ISSUER)`. The Seamless adapter verifies signed auth responses with `aud === audience`, and the deployment contract requires the adopter's `audience` to equal its `authServerUrl`, which is byte-identical to this server's `ISSUER`. Without the claim, jose rejects every token the adapter checks, so login, registration, OAuth, OTP, magic-link, and organization-switch all fail once the adapter's audience binding ships. The claim is additive and ignored by verifiers that do not check it.

--- a/src/lib/token.ts
+++ b/src/lib/token.ts
@@ -14,6 +14,10 @@ import { getSigningKey } from '../utils/signingKeyStore.js';
 
 const logger = getLogger('tokens');
 
+// User tokens are signed with `aud` equal to ISSUER. The Seamless adapter verifies
+// signed auth responses with `aud === audience`, and the deployment contract requires
+// the adopter's `audience` to equal its `authServerUrl`, which is byte-identical to
+// this ISSUER. Omitting `aud` makes jose reject every token the adapter checks.
 const ISSUER = process.env.ISSUER!;
 let warnedAboutDevLookupSecret = false;
 
@@ -66,6 +70,7 @@ export async function signAccessToken(
     .setProtectedHeader({ alg: 'RS256', kid })
     .setIssuedAt()
     .setIssuer(ISSUER)
+    .setAudience(ISSUER)
     .setExpirationTime(access_token_ttl)
     .sign(privateKey);
 
@@ -87,6 +92,7 @@ export async function signRefreshToken(sessionId: string, userId: string) {
     .setProtectedHeader({ alg: 'RS256', kid })
     .setIssuedAt()
     .setIssuer(ISSUER)
+    .setAudience(ISSUER)
     .setExpirationTime(refresh_token_ttl)
     .sign(privateKey);
 
@@ -107,6 +113,7 @@ export async function signEphemeralToken(userId: string) {
       .setProtectedHeader({ alg: 'RS256', kid })
       .setIssuedAt()
       .setIssuer(ISSUER)
+      .setAudience(ISSUER)
       .setExpirationTime('5m')
       .sign(privateKey);
 

--- a/tests/unit/lib/token.spec.ts
+++ b/tests/unit/lib/token.spec.ts
@@ -11,6 +11,7 @@ vi.mock('../../../src/config/getSystemConfig.js', () => ({
 }));
 
 const signPayloads = vi.hoisted(() => [] as unknown[]);
+const signAudiences = vi.hoisted(() => [] as unknown[]);
 
 vi.mock('jose', () => {
   class MockSignJWT {
@@ -24,6 +25,10 @@ vi.mock('jose', () => {
       return this;
     }
     setIssuer() {
+      return this;
+    }
+    setAudience(audience: unknown) {
+      signAudiences.push(audience);
       return this;
     }
     setExpirationTime() {
@@ -80,11 +85,14 @@ describe('token utils', () => {
       access_token_ttl: '15m',
     });
 
+    signAudiences.length = 0;
+
     const { signAccessToken } = await import('../../../src/lib/token');
 
     const result = await signAccessToken('sid', 'user', ['admin']);
 
     expect(result).toBe('mock-jwt');
+    expect(signAudiences.at(-1)).toBe('issuer');
   });
 
   it('embeds an organization claim when an organization id is provided', async () => {
@@ -132,11 +140,14 @@ describe('token utils', () => {
       refresh_token_ttl: '1h',
     });
 
+    signAudiences.length = 0;
+
     const { signRefreshToken } = await import('../../../src/lib/token');
 
     const result = await signRefreshToken('sid', 'user');
 
     expect(result).toBe('mock-jwt');
+    expect(signAudiences.at(-1)).toBe('issuer');
   });
 
   it('signs ephemeral token', async () => {
@@ -147,11 +158,14 @@ describe('token utils', () => {
       privateKeyPem: 'pem',
     });
 
+    signAudiences.length = 0;
+
     const { signEphemeralToken } = await import('../../../src/lib/token');
 
     const result = await signEphemeralToken('user');
 
     expect(result).toBe('mock-jwt');
+    expect(signAudiences.at(-1)).toBe('issuer');
   });
 
   it('throws if signing fails', async () => {


### PR DESCRIPTION
## Problem

The Seamless adapter now verifies signed auth responses with `aud === audience` (the unreleased `verify-audience-binding` change in `seamless-auth-server`), but no signer here ever set an `aud` claim. jose rejects a token that lacks a claim it was told to check, so once that adapter change ships, every handler calling `verifySignedAuthResponse` fails: login, finishLogin, finishRegister, OAuth, OTP, magic-link, and organization-switch. This is a release blocker on both sides.

Core's tests mock jose, which is why CI did not catch it.

## Fix

`signAccessToken`, `signRefreshToken`, and `signEphemeralToken` now call `.setAudience(ISSUER)` in addition to `.setIssuer(ISSUER)`. The deployment contract requires the adopter's `audience` to equal its `authServerUrl`, which is byte-identical to this server's `ISSUER`, so `aud === ISSUER` is exactly what the adapter checks. The claim is additive and ignored by verifiers that do not check it (the API's own `sessionService` verifies issuer only).

The token unit test now captures and asserts the bound audience, closing the jose-mock blind spot.

## Verification

- Full suite: 951 passing, 1 skipped. Typecheck and format clean.
- End to end with real jose against the built core and a live JWKS endpoint: a token with `aud` bound is accepted (`sub` returned); a token without it is rejected. This reproduces the blocker and confirms the fix.

## Coordination

Must release together with the `verify-audience-binding` change in `seamless-auth-server`. See the fixed M2M service-token contract (`iss=seamless-portal-api`, `aud=seamless-auth`), which is separate from these user-token claims and unchanged here.