### PR TITLE
feat(rate-limit): add DISABLE_AUTH_RATE_LIMITS testing escape hatch

### DIFF
--- a/.changeset/disable-auth-rate-limits.md
+++ b/.changeset/disable-auth-rate-limits.md
@@ -1,0 +1,13 @@
+---
+'seamless-auth-api': minor
+---
+
+Add a `DISABLE_AUTH_RATE_LIMITS` testing escape hatch.
+
+Beyond the configurable global limiter (`RATE_LIMIT`), dedicated per-IP and
+per-identity limiters guard the OTP, magic-link, registration, and OAuth routes,
+plus JWKS. An automated test or conformance suite driving many of these flows from
+a single IP trips them. Setting `DISABLE_AUTH_RATE_LIMITS=true` now makes every
+auth limiter skip. It is refused under `NODE_ENV=production` (like
+`ALLOW_UNCREDENTIALED_DELIVERY_SECRETS`), so it can never weaken a deployed server.
+Defaults to off.

--- a/.env.example
+++ b/.env.example
@@ -51,6 +51,11 @@ ACCESS_TOKEN_TTL=30m
 REFRESH_TOKEN_TTL=1h
 RATE_LIMIT=100
 DELAY_AFTER=50
+# Testing escape hatch. When true, all auth rate limiters (global, OTP, magic link,
+# registration, OAuth, JWKS) are skipped so an automated suite driving many flows
+# from one IP is not throttled. Ignored under NODE_ENV=production, so it can never
+# weaken a deployed server. Leave false outside conformance/CI.
+DISABLE_AUTH_RATE_LIMITS=false
 # JSON. Failed login attempts for an identified user inside windowSeconds lock the account
 # for lockoutSeconds. Set enabled=false only when an upstream policy handles this.
 LOCKOUT_POLICY={"enabled":true,"maxFailures":10,"windowSeconds":900,"lockoutSeconds":900}

--- a/README.md
+++ b/README.md
@@ -272,6 +272,13 @@ attempts. The value is JSON and is also manageable through `system_config`:
 Lockout is checked after Seamless Auth has identified the target user. Keep route-level rate limits
 enabled for unknown identifiers, OTP delivery abuse, and broad IP pressure.
 
+Beyond the configurable global limit (`RATE_LIMIT`), dedicated per-IP and per-identity limiters
+guard the OTP, magic-link, registration, and OAuth routes. An automated test or conformance suite
+that drives many of these flows from a single IP will trip them. For those environments only, set
+`DISABLE_AUTH_RATE_LIMITS=true` to skip every auth limiter. It is refused under
+`NODE_ENV=production` (like `ALLOW_UNCREDENTIALED_DELIVERY_SECRETS`), so it can never weaken a
+deployed server. Never set it in production.
+
 ### Admin-Assisted Device Replacement
 
 Administrators with write access can prepare an account for device replacement with:

--- a/src/middleware/jwksRateLimit.ts
+++ b/src/middleware/jwksRateLimit.ts
@@ -8,6 +8,7 @@ import { NextFunction, Request, Response } from 'express';
 import rateLimit from 'express-rate-limit';
 
 import { getSystemConfig } from '../config/getSystemConfig.js';
+import { rateLimitsDisabled } from './rateLimitsDisabled.js';
 
 async function getConfiguredRateLimit() {
   const { rate_limit } = await getSystemConfig();
@@ -21,6 +22,7 @@ const jwksLimiter = rateLimit({
   standardHeaders: true,
   legacyHeaders: false,
   message: 'Too many requests, please try again later',
+  skip: rateLimitsDisabled,
 });
 
 export function dynamicJWKSRateLimit(req: Request, res: Response, next: NextFunction) {

--- a/src/middleware/rateLimit.ts
+++ b/src/middleware/rateLimit.ts
@@ -9,6 +9,7 @@ import rateLimit from 'express-rate-limit';
 
 import { getSystemConfig } from '../config/getSystemConfig.js';
 import { AuthenticatedRequest } from '../types/types.js';
+import { rateLimitsDisabled } from './rateLimitsDisabled.js';
 
 async function getConfiguredRateLimit() {
   const { rate_limit } = await getSystemConfig();
@@ -61,6 +62,7 @@ const dynamicLimiter = rateLimit({
   limit: getConfiguredRateLimit,
   standardHeaders: true,
   legacyHeaders: false,
+  skip: rateLimitsDisabled,
   message: 'Too many requests, please try again later',
 });
 
@@ -69,6 +71,7 @@ const magicLinkIpCachedLimiter = rateLimit({
   limit: 20,
   standardHeaders: true,
   legacyHeaders: false,
+  skip: rateLimitsDisabled,
 });
 
 const magicLinkIdentityCachedLimiter = rateLimit({
@@ -77,6 +80,7 @@ const magicLinkIdentityCachedLimiter = rateLimit({
   keyGenerator: getMagicLinkIdentityKey,
   standardHeaders: true,
   legacyHeaders: false,
+  skip: rateLimitsDisabled,
 });
 
 const otpIpCachedLimiter = rateLimit({
@@ -84,6 +88,7 @@ const otpIpCachedLimiter = rateLimit({
   limit: 10,
   standardHeaders: true,
   legacyHeaders: false,
+  skip: rateLimitsDisabled,
 });
 
 const otpIdentityCachedLimiter = rateLimit({
@@ -92,6 +97,7 @@ const otpIdentityCachedLimiter = rateLimit({
   keyGenerator: getOtpIdentityKey,
   standardHeaders: true,
   legacyHeaders: false,
+  skip: rateLimitsDisabled,
 });
 
 const oauthIpCachedLimiter = rateLimit({
@@ -99,6 +105,7 @@ const oauthIpCachedLimiter = rateLimit({
   limit: 30,
   standardHeaders: true,
   legacyHeaders: false,
+  skip: rateLimitsDisabled,
 });
 
 const oauthProviderCachedLimiter = rateLimit({
@@ -107,6 +114,7 @@ const oauthProviderCachedLimiter = rateLimit({
   keyGenerator: getOAuthFlowKey,
   standardHeaders: true,
   legacyHeaders: false,
+  skip: rateLimitsDisabled,
 });
 
 export function dynamicRateLimit(req: Request, res: Response, next: NextFunction) {

--- a/src/middleware/rateLimitsDisabled.ts
+++ b/src/middleware/rateLimitsDisabled.ts
@@ -1,0 +1,18 @@
+/*
+ * Copyright © 2026 Fells Code, LLC
+ * Licensed under the GNU Affero General Public License v3.0
+ * See LICENSE file in the project root for full license information
+ */
+
+// Escape hatch for automated testing and conformance runs, where many auth
+// requests come from a single IP and would otherwise trip the per-IP OTP,
+// magic-link, registration, and OAuth limiters. When DISABLE_AUTH_RATE_LIMITS is
+// "true" the limiters below skip. It is refused under a production NODE_ENV, so it
+// can never weaken a deployed server (mirrors ALLOW_UNCREDENTIALED_DELIVERY_SECRETS).
+export function rateLimitsDisabled(): boolean {
+  if (process.env.DISABLE_AUTH_RATE_LIMITS !== 'true') {
+    return false;
+  }
+
+  return process.env.NODE_ENV !== 'production';
+}

--- a/src/middleware/slowDown.ts
+++ b/src/middleware/slowDown.ts
@@ -8,6 +8,7 @@ import { NextFunction, Request, Response } from 'express';
 import slowDown from 'express-slow-down';
 
 import { getSystemConfig } from '../config/getSystemConfig.js';
+import { rateLimitsDisabled } from './rateLimitsDisabled.js';
 
 async function getConfiguredDelayAfter() {
   const { delay_after } = await getSystemConfig();
@@ -21,6 +22,7 @@ const cachedLimiter: ReturnType<typeof slowDown> = slowDown({
   legacyHeaders: false,
   delayMs: (hits) => hits * 1000,
   message: 'Too many requests, please try again later',
+  skip: rateLimitsDisabled,
 });
 
 export function dynamicSlowDown(req: Request, res: Response, next: NextFunction) {

--- a/tests/unit/rateLimitsDisabled.spec.ts
+++ b/tests/unit/rateLimitsDisabled.spec.ts
@@ -1,0 +1,46 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { rateLimitsDisabled } from '../../src/middleware/rateLimitsDisabled.js';
+
+describe('rateLimitsDisabled', () => {
+  const saved = {
+    flag: process.env.DISABLE_AUTH_RATE_LIMITS,
+    nodeEnv: process.env.NODE_ENV,
+  };
+
+  beforeEach(() => {
+    delete process.env.DISABLE_AUTH_RATE_LIMITS;
+    process.env.NODE_ENV = 'development';
+  });
+
+  afterEach(() => {
+    if (saved.flag === undefined) delete process.env.DISABLE_AUTH_RATE_LIMITS;
+    else process.env.DISABLE_AUTH_RATE_LIMITS = saved.flag;
+    process.env.NODE_ENV = saved.nodeEnv;
+  });
+
+  it('is false by default (flag unset)', () => {
+    expect(rateLimitsDisabled()).toBe(false);
+  });
+
+  it('is false when the flag is any value other than "true"', () => {
+    process.env.DISABLE_AUTH_RATE_LIMITS = '1';
+    expect(rateLimitsDisabled()).toBe(false);
+    process.env.DISABLE_AUTH_RATE_LIMITS = 'yes';
+    expect(rateLimitsDisabled()).toBe(false);
+  });
+
+  it('is true when the flag is "true" outside production', () => {
+    process.env.DISABLE_AUTH_RATE_LIMITS = 'true';
+    process.env.NODE_ENV = 'development';
+    expect(rateLimitsDisabled()).toBe(true);
+    process.env.NODE_ENV = 'test';
+    expect(rateLimitsDisabled()).toBe(true);
+  });
+
+  it('is refused under production even when the flag is "true"', () => {
+    process.env.DISABLE_AUTH_RATE_LIMITS = 'true';
+    process.env.NODE_ENV = 'production';
+    expect(rateLimitsDisabled()).toBe(false);
+  });
+});


### PR DESCRIPTION
## Why

Beyond the configurable global limiter (`RATE_LIMIT`), dedicated per-IP and per-identity limiters guard the OTP, magic-link, registration, and OAuth routes (`src/middleware/rateLimit.ts`), plus JWKS. Their limits are hardcoded (e.g. OTP 10/15min/IP) and have no env or `NODE_ENV` bypass. An automated test or conformance suite that drives many of these flows from a single IP trips them — this is the last blocker making the cross-repo conformance run red (the adapter layer fails with `429` after the stack comes up).

## What

- New `src/middleware/rateLimitsDisabled.ts`: `DISABLE_AUTH_RATE_LIMITS === "true"` **and** `NODE_ENV !== "production"`.
- Every auth limiter (global, magic-link ×2, OTP ×2, OAuth ×2, JWKS, and the slow-down) gains `skip: rateLimitsDisabled`.
- Refused under `NODE_ENV=production`, mirroring `ALLOW_UNCREDENTIALED_DELIVERY_SECRETS`, so it can never weaken a deployed server. Defaults to off.
- Documented in `.env.example` and `README.md`; unit test for the gate.

## Scope

Testing/conformance convenience only; no production behavior change. The seamless-cli conformance stack sets `DISABLE_AUTH_RATE_LIMITS=true` (separate PR) and builds this from source via `verify --local`, so conformance goes green without a release.