### PR TITLE
feat: auto-grant admin to OWNER_EMAIL on signup

### DIFF
--- a/.changeset/auto-seed-owner-admin.md
+++ b/.changeset/auto-seed-owner-admin.md
@@ -1,0 +1,13 @@
+---
+'seamless-auth-api': minor
+---
+
+Auto-grant the admin role to a user who signs up with an `OWNER_EMAIL` address.
+Managed instances are provisioned with `OWNER_EMAIL` (the tenant owner, optionally
+a comma separated list); when that user first registers (email/OTP) or signs in
+through a verified OAuth profile, they receive the `admin` role in addition to the
+default roles, provided `admin` is an available role. This makes the bundled
+`/console` admin dashboard usable on a freshly provisioned instance without a
+separate bootstrap-promotion step. The grant is a no-op when `OWNER_EMAIL` is
+unset, so non-managed deployments are unchanged, and it only ever applies to an
+email whose control the signup flow has already verified.

--- a/src/controllers/registration.ts
+++ b/src/controllers/registration.ts
@@ -8,6 +8,7 @@ import { Request, Response } from 'express';
 
 import { getSystemConfig } from '../config/getSystemConfig.js';
 import { canReturnExternalDelivery } from '../lib/externalDelivery.js';
+import { withOwnerAdminRole } from '../lib/ownerAdmin.js';
 import { signEphemeralToken } from '../lib/token.js';
 import { User } from '../models/users.js';
 import { AuthEventService } from '../services/authEventService.js';
@@ -129,7 +130,11 @@ export const register = async (req: Request, res: Response) => {
       user = await User.create({
         email: normalizedEmail,
         phone: normalizedPhone,
-        roles: systemConfig.default_roles,
+        roles: withOwnerAdminRole(
+          systemConfig.default_roles,
+          normalizedEmail,
+          systemConfig.available_roles,
+        ),
         ...(bootstrapInviteTokenHash
           ? {
               challengeContext: {

--- a/src/lib/ownerAdmin.ts
+++ b/src/lib/ownerAdmin.ts
@@ -1,0 +1,55 @@
+/*
+ * Copyright © 2026 Fells Code, LLC
+ * Licensed under the GNU Affero General Public License v3.0
+ * See LICENSE file in the project root for full license information
+ */
+
+/**
+ * Managed instances are provisioned with an `OWNER_EMAIL` (the tenant owner,
+ * optionally a comma separated list). A user who signs up with an owner email is
+ * granted the admin role on account creation, so a freshly provisioned instance
+ * has a working `/console` admin without a separate bootstrap-promotion step.
+ *
+ * The grant is safe because both signup paths establish control of the email
+ * before the account is created (email OTP verification, or a verified OAuth
+ * profile), so only someone who actually receives mail at the owner address can
+ * claim it. When `OWNER_EMAIL` is unset the helpers are no-ops, so non-managed
+ * deployments are unaffected.
+ */
+
+const ADMIN_ROLE = 'admin';
+
+function ownerEmails(): Set<string> {
+  return new Set(
+    (process.env.OWNER_EMAIL ?? '')
+      .split(',')
+      .map((entry) => entry.trim().toLowerCase())
+      .filter(Boolean),
+  );
+}
+
+export function isOwnerEmail(email: string | null | undefined): boolean {
+  if (!email) {
+    return false;
+  }
+  return ownerEmails().has(email.trim().toLowerCase());
+}
+
+/**
+ * Returns `baseRoles` with the admin role appended when `email` is a configured
+ * owner email and the instance lists admin as an available role. Idempotent, and
+ * a no-op when `OWNER_EMAIL` is unset or admin is not an available role.
+ */
+export function withOwnerAdminRole(
+  baseRoles: string[],
+  email: string | null | undefined,
+  availableRoles: string[],
+): string[] {
+  if (!isOwnerEmail(email)) {
+    return baseRoles;
+  }
+  if (!availableRoles.includes(ADMIN_ROLE) || baseRoles.includes(ADMIN_ROLE)) {
+    return baseRoles;
+  }
+  return [...baseRoles, ADMIN_ROLE];
+}

--- a/src/services/oauthService.ts
+++ b/src/services/oauthService.ts
@@ -7,6 +7,7 @@
 import { createHash, createHmac, randomBytes, timingSafeEqual } from 'crypto';
 
 import { getSystemConfig } from '../config/getSystemConfig.js';
+import { withOwnerAdminRole } from '../lib/ownerAdmin.js';
 import { OAuthIdentity } from '../models/oauthIdentities.js';
 import { User } from '../models/users.js';
 import type { OAuthProviderConfig } from '../schemas/systemConfig.schema.js';
@@ -459,7 +460,11 @@ export async function resolveOAuthUser(provider: OAuthProviderConfig, profile: O
     user = await User.create({
       email: profile.email,
       phone: null,
-      roles: config.default_roles ?? [],
+      roles: withOwnerAdminRole(
+        config.default_roles ?? [],
+        profile.email,
+        config.available_roles ?? [],
+      ),
       verified: true,
       emailVerified: profile.emailVerified ?? true,
       phoneVerified: false,

--- a/tests/unit/lib/ownerAdmin.spec.ts
+++ b/tests/unit/lib/ownerAdmin.spec.ts
@@ -1,0 +1,87 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { isOwnerEmail, withOwnerAdminRole } from '../../../src/lib/ownerAdmin.js';
+
+const AVAILABLE = ['user', 'admin', 'betaUser', 'team'];
+const DEFAULTS = ['user', 'betaUser'];
+
+describe('ownerAdmin', () => {
+  const original = process.env.OWNER_EMAIL;
+
+  beforeEach(() => {
+    delete process.env.OWNER_EMAIL;
+  });
+
+  afterEach(() => {
+    if (original === undefined) {
+      delete process.env.OWNER_EMAIL;
+    } else {
+      process.env.OWNER_EMAIL = original;
+    }
+  });
+
+  describe('isOwnerEmail', () => {
+    it('is false when OWNER_EMAIL is unset', () => {
+      expect(isOwnerEmail('owner@example.com')).toBe(false);
+    });
+
+    it('matches case-insensitively and trims whitespace', () => {
+      process.env.OWNER_EMAIL = 'Owner@Example.com';
+      expect(isOwnerEmail('  owner@example.com  ')).toBe(true);
+      expect(isOwnerEmail('someone@else.com')).toBe(false);
+    });
+
+    it('matches any entry in a comma separated list', () => {
+      process.env.OWNER_EMAIL = 'a@x.com, b@y.com';
+      expect(isOwnerEmail('a@x.com')).toBe(true);
+      expect(isOwnerEmail('b@y.com')).toBe(true);
+      expect(isOwnerEmail('c@z.com')).toBe(false);
+    });
+
+    it('is false for null/undefined/empty', () => {
+      process.env.OWNER_EMAIL = 'owner@example.com';
+      expect(isOwnerEmail(null)).toBe(false);
+      expect(isOwnerEmail(undefined)).toBe(false);
+      expect(isOwnerEmail('')).toBe(false);
+    });
+  });
+
+  describe('withOwnerAdminRole', () => {
+    it('returns base roles unchanged when OWNER_EMAIL is unset', () => {
+      expect(withOwnerAdminRole(DEFAULTS, 'owner@example.com', AVAILABLE)).toEqual(DEFAULTS);
+    });
+
+    it('grants admin to a matching owner email', () => {
+      process.env.OWNER_EMAIL = 'owner@example.com';
+      expect(withOwnerAdminRole(DEFAULTS, 'owner@example.com', AVAILABLE)).toEqual([
+        ...DEFAULTS,
+        'admin',
+      ]);
+    });
+
+    it('does not grant admin to a non-owner email', () => {
+      process.env.OWNER_EMAIL = 'owner@example.com';
+      expect(withOwnerAdminRole(DEFAULTS, 'user@example.com', AVAILABLE)).toEqual(DEFAULTS);
+    });
+
+    it('does not grant admin when admin is not an available role', () => {
+      process.env.OWNER_EMAIL = 'owner@example.com';
+      expect(withOwnerAdminRole(DEFAULTS, 'owner@example.com', ['user', 'betaUser'])).toEqual(
+        DEFAULTS,
+      );
+    });
+
+    it('is idempotent when admin is already present', () => {
+      process.env.OWNER_EMAIL = 'owner@example.com';
+      const base = ['user', 'admin'];
+      expect(withOwnerAdminRole(base, 'owner@example.com', AVAILABLE)).toEqual(base);
+    });
+
+    it('does not mutate the input array', () => {
+      process.env.OWNER_EMAIL = 'owner@example.com';
+      const base = [...DEFAULTS];
+      withOwnerAdminRole(base, 'owner@example.com', AVAILABLE);
+      expect(base).toEqual(DEFAULTS);
+    });
+  });
+});


### PR DESCRIPTION
## What

Managed instances are provisioned with `OWNER_EMAIL` (the tenant owner, optionally a comma separated list), but the image never read it, so a freshly provisioned instance served `/console` with no admin who could log in. This grants the `admin` role automatically to a user who signs up with an owner email:

- Email/OTP registration (`src/controllers/registration.ts`) and verified OAuth signup (`src/services/oauthService.ts`) both route their role assignment through a new `withOwnerAdminRole` helper (`src/lib/ownerAdmin.ts`).
- Admin is added only when the email matches `OWNER_EMAIL` **and** `admin` is in `available_roles`; it is idempotent and does not mutate the input.
- A no-op when `OWNER_EMAIL` is unset, so non-managed deployments are unchanged.

Result: a managed instance's owner becomes admin the moment they sign up, so the bundled `/console` dashboard is usable without the separate `SEAMLESS_BOOTSTRAP_ENABLED`/`SEAMLESS_BOOTSTRAP_SECRET` promotion flow.

## Safety

The grant only ever applies to an email whose control the signup flow has already established, email OTP verification for registration, or a verified OAuth profile (the OAuth path already rejects unverified/missing emails). A user cannot claim admin for an owner address they do not actually receive mail at.

## Testing

- `npm run typecheck` clean, `eslint` clean on changed source.
- `prettier --check` clean.
- `vitest run tests/unit/lib/ownerAdmin.spec.ts`: 10/10 pass (unset, case/'whitespace, comma list, non-owner, admin-not-available, idempotent, no-mutation).
- Changeset added (`minor`).

## Follow-up context

Pairs with seamless-terraform-service#45 (managed instances serve `/console` via `SERVE_ADMIN_DASHBOARD=true` and run image v0.4.0). The terraform side already injects `OWNER_EMAIL`; this makes the image act on it.