### PR TITLE
docs: document OWNER_EMAIL in .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -89,6 +89,11 @@ OAUTH_PROVIDERS=[]
 OAUTH_STATE_SECRET=
 
 # ADMIN BOOTSTRAP
+# Tenant owner email (comma separated list allowed). A user who signs up with one of
+# these emails is granted the admin role on account creation, so a freshly provisioned
+# instance has a working /console admin without a separate bootstrap promotion step.
+# Leave unset on non-managed deployments to disable the grant entirely.
+OWNER_EMAIL=admin@test
 SEAMLESS_BOOTSTRAP_ENABLED=true
 SEAMLESS_BOOTSTRAP_SECRET=dev-bootstrap-secret-123
 # Development only. When true, logs bootstrap invite links/secrets for local debugging.


### PR DESCRIPTION
## Summary

`OWNER_EMAIL` is read by `src/lib/ownerAdmin.ts` to auto-grant the admin role on signup, but it was never listed in `.env.example`. This adds it to the admin bootstrap section with a local default of `admin@test`.

## Details

- Added `OWNER_EMAIL=admin@test` under `# ADMIN BOOTSTRAP`
- Documented that it accepts a comma separated list, what the grant does, and that leaving it unset disables the behavior

No runtime code changed, so this is not contract affecting.

## Testing

- `npm run lint` clean
- `npm run typecheck` clean
- `npm run format:check` clean
- `npm run test:run` 979 passed, 1 skipped