### PR TITLE
fix: honor DB_SSL and DB_URI for Postgres connectivity

### DIFF
--- a/.changeset/dry-jars-cheer.md
+++ b/.changeset/dry-jars-cheer.md
@@ -1,0 +1,14 @@
+---
+'seamless-auth-api': minor
+---
+
+Support TLS to Postgres. `DB_SSL` (`true`/`false`, or an `sslmode` value such as `require` or
+`verify-full`) and an `sslmode` query parameter on the connection string now set Sequelize's
+`dialectOptions.ssl`, and `DB_SSL_CA` supplies a server CA bundle as inline PEM or a file path.
+Certificate verification follows libpq semantics: `require` encrypts without verifying, `verify-ca`
+and `verify-full` verify, and supplying a CA bundle turns verification on. `DB_SSL_REJECT_UNAUTHORIZED`
+overrides it either way. TLS stays off by default.
+
+`DB_URI` is now accepted as an alias for `DATABASE_URL`. Connection and TLS resolution is shared
+between the running app and the startup migrations, so a connection string configured without the
+discrete `DB_*` variables no longer breaks migrations.

--- a/.env.example
+++ b/.env.example
@@ -40,6 +40,7 @@ PASSKEY_LOGIN_FALLBACK_ENABLED=true
 
 # DATABASE
 # Prefer DATABASE_URL in containers and hosted environments if you already have one.
+# DB_URI is accepted as an alias and is used when DATABASE_URL is unset.
 # DATABASE_URL=postgres://myuser:mypassword@localhost:5432/seamless_auth
 # Set to true to see SQL from both the running app and startup migrations.
 DB_LOGGING=false
@@ -48,6 +49,15 @@ DB_PORT=5432
 DB_NAME=seamless_auth
 DB_USER=myuser
 DB_PASSWORD=mypassword
+# TLS to Postgres. Off by default for local development. Set DB_SSL=true (or put
+# sslmode=require on the connection string) for managed databases such as RDS/Aurora,
+# which is required when the cluster enforces rds.force_ssl.
+# Accepted values: true/false, require, verify-ca, verify-full.
+# DB_SSL=true
+# Supply the server CA bundle (inline PEM or a file path) to verify the certificate.
+# Providing it turns certificate verification on; DB_SSL=true alone encrypts without verifying.
+# DB_SSL_CA=/etc/ssl/certs/rds-global-bundle.pem
+# DB_SSL_REJECT_UNAUTHORIZED=true
 
 # AUTH CONFIGURATION
 ACCESS_TOKEN_TTL=30m

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -35,7 +35,7 @@ For local development, these are the only values you must set (all are present i
 | `RPID`                | `localhost`             | WebAuthn relying party ID                         |
 | `ORIGINS`             | `http://localhost:5173` | WebAuthn allowed origins (comma-separated)        |
 | `API_SERVICE_TOKEN`   | `<32-byte hex>`         | Trusted server-adapter and internal bearer secret |
-| Database connectivity | see below               | `DATABASE_URL` **or** the `DB_*` set              |
+| Database connectivity | see below               | `DATABASE_URL`/`DB_URI` **or** the `DB_*` set     |
 
 Everything else is optional or environment-specific.
 
@@ -88,18 +88,45 @@ first boot.
 
 ### Database
 
-Provide **either** `DATABASE_URL` **or** the discrete `DB_*` variables. `DATABASE_URL` wins when
-set and is preferred in containers and hosted environments.
+Provide **either** a connection string (`DATABASE_URL`, or `DB_URI` as an alias) **or** the
+discrete `DB_*` variables. A connection string wins when set and is preferred in containers and
+hosted environments. The same resolution is shared by the running app and by the startup
+migrations, so both connect the same way.
 
 | Variable       | Required    | Default         | Notes                                                                         |
 | -------------- | ----------- | --------------- | ----------------------------------------------------------------------------- |
 | `DATABASE_URL` | Conditional | -               | Full Postgres connection string. If set, the `DB_*` host set is not required. |
-| `DB_HOST`      | Conditional | `localhost`     | Required when `DATABASE_URL` is unset.                                        |
-| `DB_PORT`      | Conditional | `5432`          | Required when `DATABASE_URL` is unset.                                        |
-| `DB_NAME`      | Conditional | `seamless_auth` | Required when `DATABASE_URL` is unset.                                        |
-| `DB_USER`      | Conditional | -               | Required when `DATABASE_URL` is unset.                                        |
+| `DB_URI`       | Conditional | -               | Alias for `DATABASE_URL`, used when `DATABASE_URL` is unset.                  |
+| `DB_HOST`      | Conditional | `localhost`     | Required when no connection string is set.                                    |
+| `DB_PORT`      | Conditional | `5432`          | Required when no connection string is set.                                    |
+| `DB_NAME`      | Conditional | `seamless_auth` | Required when no connection string is set.                                    |
+| `DB_USER`      | Conditional | -               | Required when no connection string is set.                                    |
 | `DB_PASSWORD`  | No          | -               | Password for `DB_USER`.                                                       |
 | `DB_LOGGING`   | Yes         | `false`         | Logs SQL from the app and startup migrations.                                 |
+
+#### TLS to Postgres
+
+TLS is **off by default**, which suits a local Postgres on loopback. Managed databases should
+turn it on, and it is mandatory when the cluster enforces it (for example Aurora/RDS with
+`rds.force_ssl = 1`).
+
+| Variable                     | Required | Default   | Notes                                                                                            |
+| ---------------------------- | -------- | --------- | ------------------------------------------------------------------------------------------------ |
+| `DB_SSL`                     | No       | off       | `true`/`false`, or an `sslmode` value: `require`, `prefer`, `allow`, `verify-ca`, `verify-full`. |
+| `DB_SSL_CA`                  | No       | -         | Server CA bundle, inline PEM or a file path. Supplying it turns certificate verification on.     |
+| `DB_SSL_REJECT_UNAUTHORIZED` | No       | see below | Forces certificate verification on or off, overriding the default for the selected mode.         |
+
+Resolution order:
+
+1. `DB_SSL` wins when set.
+2. Otherwise an `sslmode` query parameter on the connection string is honored.
+3. Otherwise TLS is off.
+
+Certificate verification follows libpq semantics: `require` (and `DB_SSL=true`) encrypts without
+verifying the server certificate, while `verify-ca` and `verify-full` verify it. Verification is
+also enabled whenever `DB_SSL_CA` is supplied. Amazon's RDS certificates chain to a private CA
+that Node does not trust by default, so verifying against RDS means pointing `DB_SSL_CA` at the
+RDS global bundle.
 
 ### WebAuthn
 

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
   "scripts": {
     "dev": "tsx watch --env-file .env src/server.ts",
     "start": "node dist/server.js",
-    "build": "tsc",
+    "build": "tsc && npm run build:copy-cjs",
+    "build:copy-cjs": "mkdir -p dist/config && cp src/config/*.cjs dist/config/",
     "typecheck": "tsc --noEmit",
     "test": "vitest",
     "test:run": "vitest run",

--- a/src/config/config.cjs
+++ b/src/config/config.cjs
@@ -4,6 +4,8 @@
  * See LICENSE file in the project root for full license information
  */
 
+const { parseDatabaseUrl, resolveDatabaseUrl, resolveSslOptions } = require('./database.cjs');
+
 function dbLoggingOption() {
   if (process.env.DB_LOGGING !== 'true') {
     return false;
@@ -12,31 +14,38 @@ function dbLoggingOption() {
   return (sql) => console.debug(sql);
 }
 
+// sequelize-cli parses a `url` key without percent-decoding credentials, so the
+// connection string is expanded here instead and handed over as discrete fields.
+function connectionSettings() {
+  const url = resolveDatabaseUrl();
+  const parsed = url ? parseDatabaseUrl(url) : null;
+
+  if (parsed) {
+    return parsed;
+  }
+
+  return {
+    username: process.env.DB_USER,
+    password: process.env.DB_PASSWORD,
+    database: process.env.DB_NAME,
+    host: process.env.DB_HOST,
+    port: process.env.DB_PORT,
+  };
+}
+
+function databaseConfig(extra = {}) {
+  const ssl = resolveSslOptions(resolveDatabaseUrl());
+
+  return {
+    ...connectionSettings(),
+    dialect: 'postgres',
+    ...(ssl ? { dialectOptions: { ssl } } : {}),
+    ...extra,
+  };
+}
+
 module.exports = {
-  development: {
-    username: process.env.DB_USER,
-    password: process.env.DB_PASSWORD,
-    database: process.env.DB_NAME,
-    host: process.env.DB_HOST,
-    port: process.env.DB_PORT,
-    dialect: 'postgres',
-    logging: dbLoggingOption(),
-  },
-  test: {
-    username: process.env.DB_USER,
-    password: process.env.DB_PASSWORD,
-    database: process.env.DB_NAME,
-    host: process.env.DB_HOST,
-    port: process.env.DB_PORT,
-    dialect: 'postgres',
-  },
-  production: {
-    username: process.env.DB_USER,
-    password: process.env.DB_PASSWORD,
-    database: process.env.DB_NAME,
-    host: process.env.DB_HOST,
-    port: process.env.DB_PORT,
-    dialect: 'postgres',
-    logging: dbLoggingOption(),
-  },
+  development: databaseConfig({ logging: dbLoggingOption() }),
+  test: databaseConfig(),
+  production: databaseConfig({ logging: dbLoggingOption() }),
 };

--- a/src/config/database.cjs
+++ b/src/config/database.cjs
@@ -1,0 +1,111 @@
+/*
+ * Copyright © 2026 Fells Code, LLC
+ * Licensed under the GNU Affero General Public License v3.0
+ * See LICENSE file in the project root for full license information
+ */
+
+// Shared by the running app (src/models/index.ts) and by sequelize-cli through
+// config.cjs, so migrations and the app always agree on connectivity and TLS.
+
+const { readFileSync } = require('fs');
+
+const SSL_DISABLED = new Set(['false', '0', 'no', 'off', 'disable']);
+const SSL_ENABLED = new Set(['true', '1', 'yes', 'on', 'require', 'prefer', 'allow']);
+const SSL_VERIFIED = new Set(['verify-ca', 'verify-full']);
+
+function resolveDatabaseUrl() {
+  const { DATABASE_URL, DB_URI, DB_HOST, DB_PORT, DB_NAME, DB_USER, DB_PASSWORD } = process.env;
+
+  if (DATABASE_URL) return DATABASE_URL;
+  if (DB_URI) return DB_URI;
+
+  if (!DB_HOST || !DB_PORT || !DB_NAME || !DB_USER) {
+    return null;
+  }
+
+  const encodedDbUser = encodeURIComponent(DB_USER);
+  const encodedDbPassword = encodeURIComponent(DB_PASSWORD ?? '');
+
+  return `postgres://${encodedDbUser}:${encodedDbPassword}@${DB_HOST}:${DB_PORT}/${DB_NAME}`;
+}
+
+function buildDatabaseUrl() {
+  const url = resolveDatabaseUrl();
+
+  if (!url) {
+    throw new Error('Missing required DB environment variables.');
+  }
+
+  return url;
+}
+
+function parseDatabaseUrl(url) {
+  try {
+    const parsed = new URL(url);
+    const database = decodeURIComponent(parsed.pathname.replace(/^\//, ''));
+
+    if (!parsed.hostname || !database) return null;
+
+    return {
+      host: parsed.hostname,
+      port: parsed.port || undefined,
+      database,
+      username: parsed.username ? decodeURIComponent(parsed.username) : undefined,
+      password: parsed.password ? decodeURIComponent(parsed.password) : undefined,
+    };
+  } catch {
+    return null;
+  }
+}
+
+function sslModeFromUrl(url) {
+  if (!url) return null;
+
+  const query = url.indexOf('?');
+  if (query === -1) return null;
+
+  return new URLSearchParams(url.slice(query + 1)).get('sslmode');
+}
+
+function readCertificateAuthority() {
+  const value = process.env.DB_SSL_CA;
+
+  if (!value) return null;
+  if (value.includes('-----BEGIN')) return value;
+
+  return readFileSync(value, 'utf8');
+}
+
+function isFalsy(value) {
+  return SSL_DISABLED.has(value.trim().toLowerCase());
+}
+
+// Returns the `ssl` value for Sequelize's `dialectOptions`, or null to leave TLS off.
+// `DB_SSL` wins over an `sslmode` carried on the connection string.
+function resolveSslOptions(url) {
+  const mode = (process.env.DB_SSL ?? sslModeFromUrl(url) ?? '').trim().toLowerCase();
+
+  if (!mode || SSL_DISABLED.has(mode)) return null;
+
+  const verifies = SSL_VERIFIED.has(mode);
+
+  if (!verifies && !SSL_ENABLED.has(mode)) {
+    throw new Error(`Unsupported DB SSL mode: ${mode}`);
+  }
+
+  const ca = readCertificateAuthority();
+  const override = process.env.DB_SSL_REJECT_UNAUTHORIZED;
+
+  // Plain `require` encrypts without verifying the server certificate, matching libpq.
+  // A supplied CA bundle or a verify-* mode turns verification on.
+  const rejectUnauthorized = override ? !isFalsy(override) : verifies || ca !== null;
+
+  return ca ? { ca, rejectUnauthorized } : { rejectUnauthorized };
+}
+
+module.exports = {
+  buildDatabaseUrl,
+  parseDatabaseUrl,
+  resolveDatabaseUrl,
+  resolveSslOptions,
+};

--- a/src/config/database.d.cts
+++ b/src/config/database.d.cts
@@ -1,0 +1,23 @@
+/*
+ * Copyright © 2026 Fells Code, LLC
+ * Licensed under the GNU Affero General Public License v3.0
+ * See LICENSE file in the project root for full license information
+ */
+
+export interface DatabaseConnection {
+  host: string;
+  port?: string;
+  database: string;
+  username?: string;
+  password?: string;
+}
+
+export interface DatabaseSslOptions {
+  ca?: string;
+  rejectUnauthorized: boolean;
+}
+
+export declare function buildDatabaseUrl(): string;
+export declare function parseDatabaseUrl(url: string): DatabaseConnection | null;
+export declare function resolveDatabaseUrl(): string | null;
+export declare function resolveSslOptions(url: string | null): DatabaseSslOptions | null;

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -9,6 +9,7 @@ import path from 'path';
 import { Sequelize } from 'sequelize';
 import { fileURLToPath } from 'url';
 
+import { buildDatabaseUrl, resolveSslOptions } from '../config/database.cjs';
 import getLogger from '../utils/logger.js';
 
 const logger = getLogger('sequelize');
@@ -20,23 +21,6 @@ const isProduction = process.env.NODE_ENV === 'production';
 const enableDbLogging = !isProduction && process.env.DB_LOGGING === 'true';
 
 let sequelizeInstance: Sequelize | null = null;
-
-function buildDatabaseUrl(): string {
-  if (process.env.DATABASE_URL) {
-    return process.env.DATABASE_URL;
-  }
-
-  const { DB_HOST, DB_PORT, DB_NAME, DB_USER, DB_PASSWORD } = process.env;
-
-  if (!DB_HOST || !DB_PORT || !DB_NAME || !DB_USER) {
-    throw new Error('Missing required DB environment variables.');
-  }
-
-  const encodedDbUser = encodeURIComponent(DB_USER);
-  const encodedDbPassword = encodeURIComponent(DB_PASSWORD ?? '');
-
-  return `postgres://${encodedDbUser}:${encodedDbPassword}@${DB_HOST}:${DB_PORT}/${DB_NAME}`;
-}
 
 export function getSequelize(): Sequelize {
   if (sequelizeInstance) return sequelizeInstance;
@@ -54,11 +38,13 @@ export function getSequelize(): Sequelize {
   }
 
   const DATABASE_URL = buildDatabaseUrl();
+  const ssl = resolveSslOptions(DATABASE_URL);
 
-  logger.info('Using Postgres database');
+  logger.info(`Using Postgres database (TLS ${ssl ? 'enabled' : 'disabled'})`);
 
   sequelizeInstance = new Sequelize(DATABASE_URL, {
     logging: enableDbLogging ? (msg) => logger.debug(msg) : false,
+    ...(ssl ? { dialectOptions: { ssl } } : {}),
   });
 
   return sequelizeInstance;

--- a/tests/unit/config/database.spec.ts
+++ b/tests/unit/config/database.spec.ts
@@ -1,0 +1,195 @@
+import { createRequire } from 'module';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  buildDatabaseUrl,
+  parseDatabaseUrl,
+  resolveDatabaseUrl,
+  resolveSslOptions,
+} from '../../../src/config/database.cjs';
+
+const DB_VARS = [
+  'DATABASE_URL',
+  'DB_URI',
+  'DB_HOST',
+  'DB_PORT',
+  'DB_NAME',
+  'DB_USER',
+  'DB_PASSWORD',
+  'DB_SSL',
+  'DB_SSL_CA',
+  'DB_SSL_REJECT_UNAUTHORIZED',
+];
+
+describe('database connection resolution', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+    for (const name of DB_VARS) delete process.env[name];
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it('prefers DATABASE_URL, then DB_URI, then the discrete vars', () => {
+    process.env.DB_HOST = 'db.internal';
+    process.env.DB_PORT = '5432';
+    process.env.DB_NAME = 'auth_db';
+    process.env.DB_USER = 'auth';
+
+    expect(resolveDatabaseUrl()).toBe('postgres://auth:@db.internal:5432/auth_db');
+
+    process.env.DB_URI = 'postgres://uri:pass@uri.example.com:5432/auth_db';
+    expect(resolveDatabaseUrl()).toBe(process.env.DB_URI);
+
+    process.env.DATABASE_URL = 'postgres://url:pass@url.example.com:5432/auth_db';
+    expect(resolveDatabaseUrl()).toBe(process.env.DATABASE_URL);
+  });
+
+  it('returns null and throws only from buildDatabaseUrl when vars are missing', () => {
+    expect(resolveDatabaseUrl()).toBeNull();
+    expect(() => buildDatabaseUrl()).toThrow('Missing required DB environment variables.');
+  });
+
+  it('round-trips percent-encoded credentials', () => {
+    process.env.DB_HOST = 'db.internal';
+    process.env.DB_PORT = '5432';
+    process.env.DB_NAME = 'auth_db';
+    process.env.DB_USER = 'review@admin';
+    process.env.DB_PASSWORD = 'p@ss:wo/rd?with#symbols';
+
+    const url = buildDatabaseUrl();
+
+    expect(url).toBe(
+      'postgres://review%40admin:p%40ss%3Awo%2Frd%3Fwith%23symbols@db.internal:5432/auth_db',
+    );
+    expect(parseDatabaseUrl(url)).toEqual({
+      host: 'db.internal',
+      port: '5432',
+      database: 'auth_db',
+      username: 'review@admin',
+      password: 'p@ss:wo/rd?with#symbols',
+    });
+  });
+
+  it('returns null for an unparseable connection string', () => {
+    expect(parseDatabaseUrl('not-a-url')).toBeNull();
+  });
+});
+
+describe('database TLS resolution', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+    for (const name of DB_VARS) delete process.env[name];
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it('leaves TLS off by default', () => {
+    expect(resolveSslOptions('postgres://auth@db.internal:5432/auth_db')).toBeNull();
+  });
+
+  it('enables TLS without certificate verification for DB_SSL=true', () => {
+    process.env.DB_SSL = 'true';
+
+    expect(resolveSslOptions(null)).toEqual({ rejectUnauthorized: false });
+  });
+
+  it('honors an sslmode carried on the connection string', () => {
+    expect(resolveSslOptions('postgres://auth@db.internal:5432/auth_db?sslmode=require')).toEqual({
+      rejectUnauthorized: false,
+    });
+
+    expect(
+      resolveSslOptions('postgres://auth@db.internal:5432/auth_db?sslmode=verify-full'),
+    ).toEqual({ rejectUnauthorized: true });
+  });
+
+  it('lets DB_SSL override the connection string sslmode', () => {
+    process.env.DB_SSL = 'false';
+
+    expect(
+      resolveSslOptions('postgres://auth@db.internal:5432/auth_db?sslmode=require'),
+    ).toBeNull();
+  });
+
+  it('verifies the server certificate when a CA bundle is supplied', () => {
+    process.env.DB_SSL = 'true';
+    process.env.DB_SSL_CA = '-----BEGIN CERTIFICATE-----\nrds\n-----END CERTIFICATE-----';
+
+    expect(resolveSslOptions(null)).toEqual({
+      ca: process.env.DB_SSL_CA,
+      rejectUnauthorized: true,
+    });
+  });
+
+  it('lets DB_SSL_REJECT_UNAUTHORIZED override the default', () => {
+    process.env.DB_SSL = 'verify-full';
+    process.env.DB_SSL_REJECT_UNAUTHORIZED = 'false';
+
+    expect(resolveSslOptions(null)).toEqual({ rejectUnauthorized: false });
+  });
+
+  it('fails loudly on an unsupported mode', () => {
+    process.env.DB_SSL = 'maybe';
+
+    expect(() => resolveSslOptions(null)).toThrow('Unsupported DB SSL mode: maybe');
+  });
+});
+
+describe('sequelize-cli config', () => {
+  const originalEnv = process.env;
+  const require = createRequire(import.meta.url);
+  const configPath = require.resolve('../../../src/config/config.cjs');
+
+  function loadConfig() {
+    delete require.cache[configPath];
+    delete require.cache[require.resolve('../../../src/config/database.cjs')];
+    return require(configPath);
+  }
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+    for (const name of DB_VARS) delete process.env[name];
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it('expands a connection string into discrete fields and applies TLS', () => {
+    process.env.DB_URI = 'postgres://review%40admin:secret@db.internal:5432/auth_db';
+    process.env.DB_SSL = 'true';
+
+    expect(loadConfig().production).toEqual({
+      host: 'db.internal',
+      port: '5432',
+      database: 'auth_db',
+      username: 'review@admin',
+      password: 'secret',
+      dialect: 'postgres',
+      dialectOptions: { ssl: { rejectUnauthorized: false } },
+      logging: false,
+    });
+  });
+
+  it('falls back to the discrete vars and omits dialectOptions when TLS is off', () => {
+    process.env.DB_HOST = 'localhost';
+
+    expect(loadConfig().production).toEqual({
+      host: 'localhost',
+      port: undefined,
+      database: undefined,
+      username: undefined,
+      password: undefined,
+      dialect: 'postgres',
+      logging: false,
+    });
+  });
+});

--- a/tests/unit/models/sequelize.spec.ts
+++ b/tests/unit/models/sequelize.spec.ts
@@ -14,6 +14,8 @@ describe('getSequelize database URL building', () => {
     vi.clearAllMocks();
     process.env = { ...originalEnv };
     delete process.env.DATABASE_URL;
+    delete process.env.DB_URI;
+    delete process.env.DB_SSL;
     delete process.env.TEST_DB;
     process.env.NODE_ENV = 'development';
     process.env.DB_LOGGING = 'false';
@@ -53,6 +55,47 @@ describe('getSequelize database URL building', () => {
       process.env.DATABASE_URL,
       expect.objectContaining({
         logging: false,
+      }),
+    );
+  });
+
+  it('passes no dialectOptions when TLS is not requested', async () => {
+    process.env.DATABASE_URL = 'postgres://user:pass@example.com:5432/auth_db';
+
+    const { getSequelize } = await import('../../../src/models/index.js');
+
+    getSequelize();
+
+    expect(sequelizeConstructor.mock.calls[0][1]).not.toHaveProperty('dialectOptions');
+  });
+
+  it('enables TLS when DB_SSL is set', async () => {
+    process.env.DATABASE_URL = 'postgres://user:pass@example.com:5432/auth_db';
+    process.env.DB_SSL = 'true';
+
+    const { getSequelize } = await import('../../../src/models/index.js');
+
+    getSequelize();
+
+    expect(sequelizeConstructor).toHaveBeenCalledWith(
+      process.env.DATABASE_URL,
+      expect.objectContaining({
+        dialectOptions: { ssl: { rejectUnauthorized: false } },
+      }),
+    );
+  });
+
+  it('uses DB_URI when DATABASE_URL is unset', async () => {
+    process.env.DB_URI = 'postgres://user:pass@example.com:5432/auth_db?sslmode=verify-full';
+
+    const { getSequelize } = await import('../../../src/models/index.js');
+
+    getSequelize();
+
+    expect(sequelizeConstructor).toHaveBeenCalledWith(
+      process.env.DB_URI,
+      expect.objectContaining({
+        dialectOptions: { ssl: { rejectUnauthorized: true } },
       }),
     );
   });

--- a/validateEnvs.sh
+++ b/validateEnvs.sh
@@ -39,6 +39,8 @@ require_var ORIGINS
 
 if [ -n "${DATABASE_URL:-}" ]; then
   echo "Using DATABASE_URL for database connectivity"
+elif [ -n "${DB_URI:-}" ]; then
+  echo "Using DB_URI for database connectivity"
 else
   require_var DB_HOST
   require_var DB_PORT


### PR DESCRIPTION
Closes #108

## Problem

The runtime built its Sequelize connection from `DATABASE_URL` or the discrete `DB_*` vars and passed no `dialectOptions.ssl`. `DB_SSL` was read nowhere in the codebase, `DB_URI` was ignored entirely, and any `sslmode` embedded in a connection string was dropped. Managed instances therefore talked to Aurora in plaintext, and would fail at migrations or `sequelize.authenticate()` the moment a cluster set `rds.force_ssl = 1`.

`src/config/config.cjs` had the same blind spot, and additionally only ever read the discrete `DB_*` vars, so a deployment configured with a connection string alone (which `validateEnvs.sh` explicitly allows) had its migrations run against unset variables.

## Change

Connection and TLS resolution now live in `src/config/database.cjs`, shared by the app (`src/models/index.ts`) and by sequelize-cli through `config.cjs`, so migrations and the running app cannot drift apart.

- `DB_SSL` accepts `true`/`false` or an `sslmode` value (`require`, `prefer`, `allow`, `verify-ca`, `verify-full`) and sets `dialectOptions.ssl`.
- When `DB_SSL` is unset, an `sslmode` query parameter on the connection string is honored.
- `DB_SSL_CA` supplies a server CA bundle as inline PEM or a file path.
- Verification follows libpq semantics: `require` encrypts without verifying, `verify-*` verifies, and supplying a CA turns verification on. `DB_SSL_REJECT_UNAUTHORIZED` overrides either way.
- An unrecognized mode throws rather than silently downgrading to plaintext.
- TLS stays off by default, so local development is unchanged.
- `DB_URI` is accepted as an alias for `DATABASE_URL`.

`config.cjs` expands the connection string into discrete fields instead of handing sequelize-cli a `url`, because its parser does not percent-decode credentials.

## Notes

Verifying against RDS needs `DB_SSL_CA` pointed at the RDS global bundle, since Amazon's certificates chain to a private CA that Node does not trust by default. `DB_SSL=true` alone encrypts without verifying, which is what `rds.force_ssl` requires at minimum.

## Checks

`npm run typecheck`, `npm run lint`, `npm run format:check`, and `npm run coverage` all pass (953 passed, 1 skipped). 18 new/updated unit tests cover the resolution matrix and the sequelize-cli config output.