### PR TITLE
feat(metrics): broaden internal analytics beyond login events

### DIFF
--- a/.changeset/lucky-geese-repeat.md
+++ b/.changeset/lucky-geese-repeat.md
@@ -1,0 +1,24 @@
+---
+'seamless-auth-api': minor
+---
+
+Broaden the internal metrics endpoints beyond login success and failure.
+
+Auth event types are now rolled up into mutually exclusive categories (`suspicious`, `login`,
+`registration`, `webauthn`, `oauth`, `magicLink`, `otp`, `totp`, `stepUp`, `token`, `system`,
+`other`). Previously the grouping matched on substrings in order, so `webauthn_login_success` and
+`oauth_login_success` were counted as plain logins and never appeared in their own buckets.
+
+- `/internal/auth-events/timeseries` buckets now carry `total` and a `categories` map.
+  `success` and `failed` stay login-only, so existing dashboards keep working.
+- `/internal/auth-events/grouped` returns the new categories in `summary` plus an `outcomes`
+  roll-up, counts in the database instead of loading every auth event into memory, and accepts
+  `from`, `to`, and `userId`.
+- `/internal/auth-events/login-stats` and `/internal/auth-events/summary` accept the same
+  `from`, `to`, and `userId` filters as the other metrics endpoints.
+
+Two date-window fixes: the timeseries used to validate `from`/`to` and then return a now-relative
+window anyway (and with `interval=day` it queried only the last 24 hours while filling 30 daily
+buckets). Buckets now span the requested window. The maximum window is also capped per interval,
+31 days for `hour` and 366 days for `day`, and an open-ended window is measured against the
+current time rather than being unbounded.

--- a/docs/admin-operations.md
+++ b/docs/admin-operations.md
@@ -62,3 +62,45 @@ Lockout is checked after a user has been identified. Keep route-level and destin
 ## Audit Events
 
 Admin actions are recorded as auth events with redacted metadata. Do not store raw secrets, tokens, OTPs, magic-link URLs, PRF values, account keys, or provider tokens in admin metadata.
+
+## Metrics
+
+The `/internal/auth-events/*` endpoints all accept the same query parameters: `from`, `to`,
+`userId`, and `interval` (`hour` or `day`, timeseries only).
+
+### Date windows
+
+`from` and `to` are parsed as dates and rejected with `400` when unparseable or inverted. The
+window is also capped by the bucket size it would be rendered at, so an hourly series cannot be
+asked for a year of buckets:
+
+| `interval` | Maximum window |
+| ---------- | -------------- |
+| `hour`     | 31 days        |
+| `day`      | 366 days       |
+
+A window with `from` but no `to` runs to the current time and is measured the same way, so
+`?from=2020-01-01` is rejected rather than silently truncated.
+
+`/auth-events/timeseries` returns one bucket per interval across the requested window. With no
+window it falls back to the last 24 hourly buckets, or the last 30 daily buckets for
+`interval=day`.
+
+### Categories
+
+Auth event types are rolled up into mutually exclusive categories, so the counts in a summary sum
+to the total number of events:
+
+`suspicious`, `login`, `registration`, `webauthn`, `oauth`, `magicLink`, `otp`, `totp`, `stepUp`,
+`token`, `system`, `other`.
+
+`suspicious` is matched first, so a security signal lands in one bucket rather than being split
+across the surface it came from. Everything else is matched on the event-type prefix, which keeps
+`webauthn_login_success` in `webauthn` rather than `login`.
+
+`/auth-events/grouped` returns these categories in `summary`, plus an `outcomes` roll-up
+(`success`, `failed`, `suspicious`, `other`) derived from the event-type suffix.
+
+Each `/auth-events/timeseries` bucket carries `total` and a `categories` map alongside `success`
+and `failed`. Those two stay login-only for backwards compatibility with existing dashboards; use
+`categories` for OTP, WebAuthn, magic link, and OAuth activity.

--- a/resources/coverage-badge.svg
+++ b/resources/coverage-badge.svg
@@ -1,5 +1,5 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="111" height="20" role="img" aria-label="coverage: 99.5%">
-  <title>coverage: 99.5%</title>
+<svg xmlns="http://www.w3.org/2000/svg" width="111" height="20" role="img" aria-label="coverage: 99.4%">
+  <title>coverage: 99.4%</title>
   <linearGradient id="smooth" x2="0" y2="100%">
     <stop offset="0" stop-color="#fff" stop-opacity=".7"/>
     <stop offset=".1" stop-color="#aaa" stop-opacity=".1"/>
@@ -17,7 +17,7 @@
   <g fill="#fff" text-anchor="middle" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" font-size="11">
     <text x="33" y="15" fill="#010101" fill-opacity=".3">coverage</text>
     <text x="33" y="14">coverage</text>
-    <text x="88.5" y="15" fill="#010101" fill-opacity=".3">99.5%</text>
-    <text x="88.5" y="14">99.5%</text>
+    <text x="88.5" y="15" fill="#010101" fill-opacity=".3">99.4%</text>
+    <text x="88.5" y="14">99.4%</text>
   </g>
 </svg>

--- a/src/controllers/internalMetrics.ts
+++ b/src/controllers/internalMetrics.ts
@@ -7,11 +7,22 @@
 import { Request, Response } from 'express';
 import { col, fn, literal, Op, WhereOptions } from 'sequelize';
 
+import {
+  AuthEventCategory,
+  AuthEventOutcome,
+  authEventOutcome,
+  categorizeAuthEvent,
+} from '../lib/authEventCategories.js';
 import { AuthEvent, AuthEventAttributes } from '../models/authEvents.js';
-import { MetricsQuerySchema } from '../schemas/internal.query.js';
+import { MetricsInterval, MetricsQuerySchema } from '../schemas/internal.query.js';
 import getLogger from '../utils/logger.js';
 
 const logger = getLogger('internal-metrics');
+
+const HOUR_MS = 1000 * 60 * 60;
+const DAY_MS = HOUR_MS * 24;
+
+const DEFAULT_BUCKET_COUNT: Record<MetricsInterval, number> = { hour: 24, day: 30 };
 
 type TimeseriesRow = {
   bucket: Date | string;
@@ -27,6 +38,8 @@ type BucketStats = {
   bucket: string;
   success: number;
   failed: number;
+  total: number;
+  categories: Partial<Record<AuthEventCategory, number>>;
 };
 
 type SummaryRow = {
@@ -40,38 +53,87 @@ type SummaryResultInstance = {
   type: string;
 };
 
-export const getAuthEventSummary = async (req: Request, res: Response) => {
+type MetricsQuery = ReturnType<typeof MetricsQuerySchema.parse>;
+
+function truncateToInterval(date: Date, interval: MetricsInterval): Date {
+  const truncated = new Date(date);
+
+  if (interval === 'day') {
+    truncated.setUTCHours(0, 0, 0, 0);
+  } else {
+    truncated.setUTCMinutes(0, 0, 0);
+  }
+
+  return truncated;
+}
+
+// The buckets returned have to match the rows queried, otherwise a requested window is
+// validated and then quietly replaced by a now-relative one in the output.
+function resolveBucketWindow(
+  from: Date | undefined,
+  to: Date | undefined,
+  interval: MetricsInterval,
+) {
+  const step = interval === 'day' ? DAY_MS : HOUR_MS;
+  const last = truncateToInterval(to ?? new Date(), interval);
+  const first = from
+    ? truncateToInterval(from, interval)
+    : new Date(last.getTime() - step * (DEFAULT_BUCKET_COUNT[interval] - 1));
+
+  return { first, last, step };
+}
+
+function scopeWhere(
+  query: MetricsQuery,
+  from: Date | undefined,
+  to: Date | undefined,
+): WhereOptions<AuthEventAttributes> {
+  return {
+    ...(query.userId ? { user_id: query.userId } : {}),
+    ...(from || to
+      ? {
+          created_at: {
+            ...(from ? { [Op.gte]: from } : {}),
+            ...(to ? { [Op.lte]: to } : {}),
+          },
+        }
+      : {}),
+  };
+}
+
+function parseMetricsQuery(req: Request) {
   const parsed = MetricsQuerySchema.safeParse(req.query);
 
-  if (!parsed.success) {
+  if (!parsed.success) return null;
+
+  return {
+    query: parsed.data,
+    from: parsed.data.from ? new Date(parsed.data.from) : undefined,
+    to: parsed.data.to ? new Date(parsed.data.to) : undefined,
+  };
+}
+
+async function countByType(where: WhereOptions<AuthEventAttributes>) {
+  const results = (await AuthEvent.findAll({
+    attributes: ['type', [fn('COUNT', col('type')), 'count']],
+    where,
+    group: ['type'],
+  })) as SummaryResultInstance[];
+
+  return results.map((row) => ({ type: row.type, count: Number(row.get('count')) }));
+}
+
+export const getAuthEventSummary = async (req: Request, res: Response) => {
+  const parsed = parseMetricsQuery(req);
+
+  if (!parsed) {
     return res.status(400).json({ message: 'Invalid query params' });
   }
 
-  const { from, to } = parsed.data;
-
-  const where: WhereOptions<AuthEventAttributes> =
-    from || to
-      ? {
-          created_at: {
-            ...(from ? { [Op.gte]: new Date(from) } : {}),
-            ...(to ? { [Op.lte]: new Date(to) } : {}),
-          },
-        }
-      : {};
+  const { query, from, to } = parsed;
 
   try {
-    const results = (await AuthEvent.findAll({
-      attributes: ['type', [fn('COUNT', col('type')), 'count']],
-      where,
-      group: ['type'],
-    })) as SummaryResultInstance[];
-
-    return res.json({
-      summary: results.map((r: SummaryResultInstance) => ({
-        type: r.type,
-        count: Number(r.get('count')),
-      })),
-    });
+    return res.json({ summary: await countByType(scopeWhere(query, from, to)) });
   } catch (err) {
     logger.error(`Failed to fetch auth summary: ${err}`);
     return res.status(500).json({ message: 'Failed to fetch summary' });
@@ -79,40 +141,25 @@ export const getAuthEventSummary = async (req: Request, res: Response) => {
 };
 
 export const getAuthEventTimeseries = async (req: Request, res: Response) => {
-  const parsed = MetricsQuerySchema.safeParse(req.query);
+  const parsed = parseMetricsQuery(req);
 
-  if (!parsed.success) {
+  if (!parsed) {
     return res.status(400).json({ message: 'Invalid query params' });
   }
 
-  const { from, to, interval, userId } = parsed.data;
-
-  // Default to last 24h if not provided
-  const now = new Date();
-  const defaultFrom = new Date(now.getTime() - 1000 * 60 * 60 * 24);
-
-  const createdAtFilter =
-    from || to
-      ? {
-          ...(from ? { [Op.gte]: new Date(from) } : {}),
-          ...(to ? { [Op.lte]: new Date(to) } : {}),
-        }
-      : {
-          [Op.gte]: defaultFrom,
-        };
+  const { query, from, to } = parsed;
+  const { first, last, step } = resolveBucketWindow(from, to, query.interval);
 
   const where: WhereOptions<AuthEventAttributes> = {
-    type: {
-      [Op.in]: ['login_success', 'login_failed'],
+    ...(query.userId ? { user_id: query.userId } : {}),
+    created_at: {
+      [Op.gte]: first,
+      ...(to ? { [Op.lte]: to } : { [Op.lt]: new Date(last.getTime() + step) }),
     },
-
-    ...(userId ? { user_id: userId } : {}),
-
-    created_at: createdAtFilter,
   };
 
   const bucket =
-    interval === 'day'
+    query.interval === 'day'
       ? literal(`DATE_TRUNC('day', created_at)`)
       : literal(`DATE_TRUNC('hour', created_at)`);
 
@@ -127,59 +174,34 @@ export const getAuthEventTimeseries = async (req: Request, res: Response) => {
     const map: Record<string, BucketStats> = {};
 
     for (const r of results as ResultInstance[]) {
-      const bucket = new Date(r.get('bucket')).toISOString();
+      const key = new Date(r.get('bucket')).toISOString();
       const type = r.get('type');
       const count = Number(r.get('count'));
 
-      if (!map[bucket]) {
-        map[bucket] = {
-          bucket,
-          success: 0,
-          failed: 0,
-        };
-      }
+      map[key] ??= { bucket: key, success: 0, failed: 0, total: 0, categories: {} };
+
+      const stats = map[key];
+      const category = categorizeAuthEvent(type);
+
+      stats.total += count;
+      stats.categories[category] = (stats.categories[category] ?? 0) + count;
 
       if (type === 'login_success') {
-        map[bucket].success = count;
+        stats.success = count;
       } else if (type === 'login_failed') {
-        map[bucket].failed = count;
+        stats.failed = count;
       }
     }
 
-    const filled: BucketStats[] = [];
+    const timeseries: BucketStats[] = [];
 
-    if (interval === 'day') {
-      for (let i = 29; i >= 0; i--) {
-        const d = new Date(now);
-        d.setUTCDate(d.getUTCDate() - i);
-        d.setUTCHours(0, 0, 0, 0);
+    for (let time = first.getTime(); time <= last.getTime(); time += step) {
+      const key = new Date(time).toISOString();
 
-        const key = d.toISOString();
-
-        filled.push({
-          bucket: key,
-          success: map[key]?.success ?? 0,
-          failed: map[key]?.failed ?? 0,
-        });
-      }
-    } else {
-      for (let i = 23; i >= 0; i--) {
-        const d = new Date(now);
-        d.setUTCHours(d.getUTCHours() - i, 0, 0, 0);
-
-        const key = d.toISOString();
-
-        filled.push({
-          bucket: key,
-          success: map[key]?.success ?? 0,
-          failed: map[key]?.failed ?? 0,
-        });
-      }
+      timeseries.push(map[key] ?? { bucket: key, success: 0, failed: 0, total: 0, categories: {} });
     }
 
-    return res.json({
-      timeseries: filled,
-    });
+    return res.json({ timeseries });
   } catch (err) {
     logger.error(`Failed to fetch timeseries: ${err}`);
     return res.status(500).json({ message: 'Failed to fetch timeseries' });
@@ -187,14 +209,18 @@ export const getAuthEventTimeseries = async (req: Request, res: Response) => {
 };
 
 export const getLoginStats = async (req: Request, res: Response) => {
-  try {
-    const success = await AuthEvent.count({
-      where: { type: 'login_success' },
-    });
+  const parsed = parseMetricsQuery(req);
 
-    const failed = await AuthEvent.count({
-      where: { type: 'login_failed' },
-    });
+  if (!parsed) {
+    return res.status(400).json({ message: 'Invalid query params' });
+  }
+
+  const { query, from, to } = parsed;
+  const scope = scopeWhere(query, from, to);
+
+  try {
+    const success = await AuthEvent.count({ where: { ...scope, type: 'login_success' } });
+    const failed = await AuthEvent.count({ where: { ...scope, type: 'login_failed' } });
 
     return res.json({
       success,
@@ -202,44 +228,40 @@ export const getLoginStats = async (req: Request, res: Response) => {
       successRate: success + failed > 0 ? success / (success + failed) : 0,
     });
   } catch (err) {
-    logger.error(`Failed to get Auth Events timeseries data. Reason: ${err}`);
+    logger.error(`Failed to compute login stats: ${err}`);
     return res.status(500).json({ message: 'Failed to compute login stats' });
   }
 };
 
-export const getGroupedEventSummary = async (_req: Request, res: Response) => {
+export const getGroupedEventSummary = async (req: Request, res: Response) => {
+  const parsed = parseMetricsQuery(req);
+
+  if (!parsed) {
+    return res.status(400).json({ message: 'Invalid query params' });
+  }
+
+  const { query, from, to } = parsed;
+
   try {
-    const events = await AuthEvent.findAll();
+    const byType = await countByType(scopeWhere(query, from, to));
 
-    const grouped = {
-      login: 0,
-      otp: 0,
-      webauthn: 0,
-      magicLink: 0,
-      system: 0,
-      suspicious: 0,
-      other: 0,
-    };
+    const categories = new Map<AuthEventCategory, number>();
+    const outcomes = new Map<AuthEventOutcome, number>();
 
-    for (const e of events) {
-      const type = e.type;
+    for (const { type, count } of byType) {
+      const category = categorizeAuthEvent(type);
+      const outcome = authEventOutcome(type);
 
-      if (type.includes('login')) grouped.login++;
-      else if (type.includes('otp')) grouped.otp++;
-      else if (type.includes('webauthn')) grouped.webauthn++;
-      else if (type.includes('magic_link')) grouped.magicLink++;
-      else if (type.includes('system_config')) grouped.system++;
-      else if (type.includes('suspicious')) grouped.suspicious++;
-      else grouped.other++;
+      categories.set(category, (categories.get(category) ?? 0) + count);
+      outcomes.set(outcome, (outcomes.get(outcome) ?? 0) + count);
     }
 
     return res.json({
-      summary: Object.entries(grouped).map(([type, count]) => ({
-        type,
-        count,
-      })),
+      summary: [...categories].map(([type, count]) => ({ type, count })),
+      outcomes: [...outcomes].map(([type, count]) => ({ type, count })),
     });
-  } catch {
+  } catch (err) {
+    logger.error(`Failed to group auth events: ${err}`);
     return res.status(500).json({ message: 'Failed to group events' });
   }
 };

--- a/src/lib/authEventCategories.ts
+++ b/src/lib/authEventCategories.ts
@@ -1,0 +1,82 @@
+/*
+ * Copyright © 2026 Fells Code, LLC
+ * Licensed under the GNU Affero General Public License v3.0
+ * See LICENSE file in the project root for full license information
+ */
+
+export const AUTH_EVENT_CATEGORIES = [
+  'suspicious',
+  'login',
+  'registration',
+  'webauthn',
+  'oauth',
+  'magicLink',
+  'otp',
+  'totp',
+  'stepUp',
+  'token',
+  'system',
+  'other',
+] as const;
+
+export type AuthEventCategory = (typeof AUTH_EVENT_CATEGORIES)[number];
+
+export const AUTH_EVENT_OUTCOMES = ['success', 'failed', 'suspicious', 'other'] as const;
+
+export type AuthEventOutcome = (typeof AUTH_EVENT_OUTCOMES)[number];
+
+const PREFIX_CATEGORIES: ReadonlyArray<[string, AuthEventCategory]> = [
+  ['webauthn_', 'webauthn'],
+  ['oauth_', 'oauth'],
+  ['magic_link', 'magicLink'],
+  ['totp_', 'totp'],
+  ['step_up_', 'stepUp'],
+  ['mfa_otp_', 'otp'],
+  ['recovery_otp_', 'otp'],
+  ['verify_otp_', 'otp'],
+  ['otp_', 'otp'],
+  ['registration_', 'registration'],
+  ['login_', 'login'],
+  ['logout_', 'login'],
+  ['refresh_token_', 'token'],
+  ['bearer_token_', 'token'],
+  ['service_token_', 'token'],
+  ['jwks_', 'token'],
+  ['system_config_', 'system'],
+  ['admin_', 'system'],
+  ['user_data_', 'system'],
+];
+
+const EXACT_CATEGORIES: Readonly<Record<string, AuthEventCategory>> = {
+  auth_action_incremented: 'system',
+  credentials_deleted: 'webauthn',
+  informational: 'system',
+  internal_user_updated_by_owner: 'system',
+  notification_sent: 'system',
+  user_created: 'registration',
+  user_deleted: 'system',
+};
+
+// `suspicious` is checked first so security signals stay in one bucket rather than
+// being split across the surface they came from. Categories are mutually exclusive,
+// so the counts in a summary sum to the total number of events.
+export function categorizeAuthEvent(type: string): AuthEventCategory {
+  if (type.endsWith('_suspicious')) return 'suspicious';
+
+  const exact = EXACT_CATEGORIES[type];
+  if (exact) return exact;
+
+  for (const [prefix, category] of PREFIX_CATEGORIES) {
+    if (type.startsWith(prefix)) return category;
+  }
+
+  return 'other';
+}
+
+export function authEventOutcome(type: string): AuthEventOutcome {
+  if (type.endsWith('_suspicious')) return 'suspicious';
+  if (type.endsWith('_failed') || type.endsWith('_error')) return 'failed';
+  if (type.endsWith('_success') || type.endsWith('_successfully')) return 'success';
+
+  return 'other';
+}

--- a/src/routes/internal.routes.ts
+++ b/src/routes/internal.routes.ts
@@ -20,6 +20,7 @@ import {
   AuthEventSummaryResponseSchema,
   AuthEventTimeseriesResponseSchema,
   DashboardMetricsResponseSchema,
+  GroupedAuthEventSummaryResponseSchema,
   LoginStatsResponseSchema,
   SecurityAnomaliesResponseSchema,
 } from '../schemas/internalMetrics.responses.js';
@@ -69,8 +70,10 @@ internalRouter.get(
     middleware: [requireAdmin('read')],
     tags: ['Internal'],
     schemas: {
+      query: MetricsQuerySchema,
       response: {
         200: LoginStatsResponseSchema,
+        400: MessageSchema,
         500: MessageSchema,
       },
     },
@@ -120,8 +123,10 @@ internalRouter.get(
     summary: 'Auth Event metrics grouped',
     tags: ['Internal'],
     schemas: {
+      query: MetricsQuerySchema,
       response: {
-        200: AuthEventSummaryResponseSchema,
+        200: GroupedAuthEventSummaryResponseSchema,
+        400: MessageSchema,
         500: MessageSchema,
       },
     },

--- a/src/schemas/internal.query.ts
+++ b/src/schemas/internal.query.ts
@@ -26,14 +26,25 @@ export const AuthEventQuerySchema = z.object({
   to: z.string().optional(),
 });
 
-const MAX_METRICS_WINDOW_MS = 1000 * 60 * 60 * 24 * 366; // ~1 year
+const DAY_MS = 1000 * 60 * 60 * 24;
+
+// A window is capped by the bucket size it would be rendered at, so an hourly
+// timeseries cannot be asked for a year of buckets.
+export const MAX_METRICS_WINDOW_MS: Record<MetricsInterval, number> = {
+  hour: DAY_MS * 31,
+  day: DAY_MS * 366,
+};
+
+const MetricsIntervalEnum = z.enum(['hour', 'day']);
+
+export type MetricsInterval = z.infer<typeof MetricsIntervalEnum>;
 
 export const MetricsQuerySchema = z
   .object({
     userId: z.string().optional(),
     from: z.string().optional(),
     to: z.string().optional(),
-    interval: z.enum(['hour', 'day']).optional().default('hour'),
+    interval: MetricsIntervalEnum.optional().default('hour'),
   })
   .superRefine((data, ctx) => {
     const fromDate = data.from ? new Date(data.from) : undefined;
@@ -50,15 +61,21 @@ export const MetricsQuerySchema = z
       ctx.addIssue({ code: 'custom', path: ['to'], message: 'Invalid to date' });
     }
 
-    if (fromValid && toValid) {
-      if (fromDate!.getTime() > toDate!.getTime()) {
-        ctx.addIssue({ code: 'custom', path: ['to'], message: 'from must be on or before to' });
-      } else if (toDate!.getTime() - fromDate!.getTime() > MAX_METRICS_WINDOW_MS) {
-        ctx.addIssue({
-          code: 'custom',
-          path: ['to'],
-          message: 'time range exceeds the maximum window',
-        });
-      }
+    if (!fromValid) return;
+
+    // An open-ended window runs to now, so it is measured and capped the same way.
+    const end = toValid ? toDate!.getTime() : Date.now();
+
+    if (fromDate!.getTime() > end) {
+      ctx.addIssue({ code: 'custom', path: ['to'], message: 'from must be on or before to' });
+      return;
+    }
+
+    if (end - fromDate!.getTime() > MAX_METRICS_WINDOW_MS[data.interval]) {
+      ctx.addIssue({
+        code: 'custom',
+        path: ['to'],
+        message: `time range exceeds the maximum window for the ${data.interval} interval`,
+      });
     }
   });

--- a/src/schemas/internalMetrics.responses.ts
+++ b/src/schemas/internalMetrics.responses.ts
@@ -15,14 +15,23 @@ export const AuthEventSummaryResponseSchema = z.object({
   summary: z.array(AuthEventSummaryItemSchema),
 });
 
+// `success` and `failed` stay login-only for backwards compatibility. `total` and
+// `categories` cover the rest of the auth surface (OTP, WebAuthn, magic link, OAuth, ...).
 export const AuthEventTimeseriesResponseSchema = z.object({
   timeseries: z.array(
     z.object({
       bucket: z.string(),
       success: z.number(),
       failed: z.number(),
+      total: z.number(),
+      categories: z.record(z.string(), z.number()),
     }),
   ),
+});
+
+export const GroupedAuthEventSummaryResponseSchema = z.object({
+  summary: z.array(AuthEventSummaryItemSchema),
+  outcomes: z.array(AuthEventSummaryItemSchema),
 });
 
 export const LoginStatsResponseSchema = z.object({

--- a/tests/integration/internal/internal.spec.ts
+++ b/tests/integration/internal/internal.spec.ts
@@ -203,21 +203,66 @@ describe('GET /internal/metrics/dashboard', () => {
 });
 
 describe('GET /internal/auth-events/grouped', () => {
-  it('returns grouped summary', async () => {
+  const countRow = (type: string, count: string) => ({
+    type,
+    get: (key: string) => (key === 'count' ? count : type),
+  });
+
+  it('rolls counts up into categories and outcomes', async () => {
     (AuthEvent.findAll as any).mockResolvedValue([
-      { type: 'login_success' },
-      { type: 'otp_success' },
-      { type: 'webauthn_login_success' },
-      { type: 'magic_link_requested' },
-      { type: 'system_config_updated' },
-      { type: 'login_suspicious' },
-      { type: 'unknown' },
+      countRow('login_success', '4'),
+      countRow('otp_success', '3'),
+      countRow('webauthn_login_success', '2'),
+      countRow('magic_link_requested', '1'),
+      countRow('system_config_updated', '1'),
+      countRow('login_suspicious', '5'),
+      countRow('unknown', '1'),
     ]);
 
     const res = await request(app).get('/internal/auth-events/grouped');
+    const byType = Object.fromEntries(
+      res.body.summary.map((row: { type: string; count: number }) => [row.type, row.count]),
+    );
+    const outcomes = Object.fromEntries(
+      res.body.outcomes.map((row: { type: string; count: number }) => [row.type, row.count]),
+    );
 
     expect(res.status).toBe(200);
-    expect(res.body.summary).toBeDefined();
+    expect(byType).toEqual({
+      login: 4,
+      otp: 3,
+      webauthn: 2,
+      magicLink: 1,
+      system: 1,
+      suspicious: 5,
+      other: 1,
+    });
+    expect(outcomes).toEqual({ success: 9, suspicious: 5, other: 3 });
+  });
+
+  it('counts in the database rather than loading every event', async () => {
+    (AuthEvent.findAll as any).mockResolvedValue([]);
+
+    await request(app).get('/internal/auth-events/grouped');
+
+    expect((AuthEvent.findAll as any).mock.calls[0][0].group).toEqual(['type']);
+  });
+
+  it('applies a from/to created_at filter', async () => {
+    (AuthEvent.findAll as any).mockResolvedValue([]);
+
+    const res = await request(app)
+      .get('/internal/auth-events/grouped')
+      .query({ from: '2026-01-01', to: '2026-02-01' });
+
+    expect(res.status).toBe(200);
+    expect((AuthEvent.findAll as any).mock.calls[0][0].where.created_at).toBeDefined();
+  });
+
+  it('returns 400 for an invalid query', async () => {
+    const res = await request(app).get('/internal/auth-events/grouped?from=bad');
+
+    expect(res.status).toBe(400);
   });
 
   it('returns 500 when grouping fails', async () => {
@@ -253,18 +298,16 @@ describe('GET /internal/auth-events/summary (additional branches)', () => {
 });
 
 describe('GET /internal/auth-events/timeseries (additional branches)', () => {
-  it('fills daily buckets from login_success and login_failed rows', async () => {
-    const day = new Date();
-    day.setUTCHours(0, 0, 0, 0);
-    const key = day.toISOString();
+  const bucketRow = (bucket: string, type: string, count: string) => ({
+    get: (k: string) => (k === 'bucket' ? bucket : k === 'type' ? type : count),
+  });
 
-    const row = (type: string, count: string) => ({
-      get: (k: string) => (k === 'bucket' ? key : k === 'type' ? type : count),
-    });
+  it('fills daily buckets across the requested window', async () => {
+    const key = '2026-01-05T00:00:00.000Z';
 
     (AuthEvent.findAll as any).mockResolvedValue([
-      row('login_success', '5'),
-      row('login_failed', '3'),
+      bucketRow(key, 'login_success', '5'),
+      bucketRow(key, 'login_failed', '3'),
     ]);
 
     const res = await request(app)
@@ -272,10 +315,47 @@ describe('GET /internal/auth-events/timeseries (additional branches)', () => {
       .query({ interval: 'day', from: '2026-01-01', to: '2026-02-01', userId: 'user-1' });
 
     expect(res.status).toBe(200);
-    expect(res.body.timeseries).toHaveLength(30);
+    // Jan 1 through Feb 1 inclusive, rather than a now-relative 30-day window.
+    expect(res.body.timeseries).toHaveLength(32);
+    expect(res.body.timeseries[0].bucket).toBe('2026-01-01T00:00:00.000Z');
+    expect(res.body.timeseries.at(-1).bucket).toBe('2026-02-01T00:00:00.000Z');
+
     const filled = res.body.timeseries.find((b: any) => b.bucket === key);
-    expect(filled).toMatchObject({ success: 5, failed: 3 });
+    expect(filled).toMatchObject({ success: 5, failed: 3, total: 8, categories: { login: 8 } });
     expect((AuthEvent.findAll as any).mock.calls[0][0].where.user_id).toBe('user-1');
+  });
+
+  it('defaults to the last 24 hourly buckets when no window is given', async () => {
+    (AuthEvent.findAll as any).mockResolvedValue([]);
+
+    const res = await request(app).get('/internal/auth-events/timeseries');
+
+    expect(res.status).toBe(200);
+    expect(res.body.timeseries).toHaveLength(24);
+  });
+
+  it('counts non-login activity into categories', async () => {
+    const key = '2026-01-05T00:00:00.000Z';
+
+    (AuthEvent.findAll as any).mockResolvedValue([
+      bucketRow(key, 'otp_success', '4'),
+      bucketRow(key, 'webauthn_login_success', '2'),
+      bucketRow(key, 'magic_link_requested', '1'),
+    ]);
+
+    const res = await request(app)
+      .get('/internal/auth-events/timeseries')
+      .query({ interval: 'day', from: '2026-01-05', to: '2026-01-05' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.timeseries).toHaveLength(1);
+    expect(res.body.timeseries[0]).toMatchObject({
+      bucket: key,
+      success: 0,
+      failed: 0,
+      total: 7,
+      categories: { otp: 4, webauthn: 2, magicLink: 1 },
+    });
   });
 
   it('returns 500 when the timeseries query fails', async () => {

--- a/tests/unit/lib/authEventCategories.spec.ts
+++ b/tests/unit/lib/authEventCategories.spec.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  authEventOutcome,
+  AUTH_EVENT_CATEGORIES,
+  categorizeAuthEvent,
+} from '../../../src/lib/authEventCategories.js';
+import { AUTH_EVENT_TYPES } from '../../../src/schemas/authEvent.types.js';
+
+describe('categorizeAuthEvent', () => {
+  it('keeps WebAuthn and OAuth logins out of the generic login bucket', () => {
+    expect(categorizeAuthEvent('webauthn_login_success')).toBe('webauthn');
+    expect(categorizeAuthEvent('webauthn_registration_failed')).toBe('webauthn');
+    expect(categorizeAuthEvent('oauth_login_started')).toBe('oauth');
+    expect(categorizeAuthEvent('login_success')).toBe('login');
+    expect(categorizeAuthEvent('logout_success')).toBe('login');
+  });
+
+  it('groups every OTP variant together and keeps TOTP separate', () => {
+    expect(categorizeAuthEvent('otp_success')).toBe('otp');
+    expect(categorizeAuthEvent('mfa_otp_failed')).toBe('otp');
+    expect(categorizeAuthEvent('recovery_otp_success')).toBe('otp');
+    expect(categorizeAuthEvent('verify_otp_failed')).toBe('otp');
+    expect(categorizeAuthEvent('totp_enrollment_success')).toBe('totp');
+  });
+
+  it('routes suspicious events to the security bucket regardless of surface', () => {
+    expect(categorizeAuthEvent('login_suspicious')).toBe('suspicious');
+    expect(categorizeAuthEvent('webauthn_login_suspicious')).toBe('suspicious');
+    expect(categorizeAuthEvent('request_suspicious')).toBe('suspicious');
+  });
+
+  it('falls back to other for an unrecognized type', () => {
+    expect(categorizeAuthEvent('something_new')).toBe('other');
+  });
+
+  it('assigns every known event type to a declared category', () => {
+    for (const type of AUTH_EVENT_TYPES) {
+      expect(AUTH_EVENT_CATEGORIES).toContain(categorizeAuthEvent(type));
+    }
+  });
+
+  it('leaves no known event type in the other bucket', () => {
+    const uncategorized = AUTH_EVENT_TYPES.filter((type) => categorizeAuthEvent(type) === 'other');
+
+    expect(uncategorized).toEqual([]);
+  });
+});
+
+describe('authEventOutcome', () => {
+  it('derives the outcome from the type suffix', () => {
+    expect(authEventOutcome('login_success')).toBe('success');
+    expect(authEventOutcome('magic_link_poll_completed_successfully')).toBe('success');
+    expect(authEventOutcome('login_failed')).toBe('failed');
+    expect(authEventOutcome('system_config_error')).toBe('failed');
+    expect(authEventOutcome('login_suspicious')).toBe('suspicious');
+    expect(authEventOutcome('magic_link_requested')).toBe('other');
+  });
+});

--- a/tests/unit/schemas/metricsQuery.spec.ts
+++ b/tests/unit/schemas/metricsQuery.spec.ts
@@ -50,4 +50,25 @@ describe('MetricsQuerySchema', () => {
 
     expect(parsed.success).toBe(false);
   });
+
+  it('caps the window by the requested bucket size', () => {
+    const range = { from: '2026-01-01T00:00:00.000Z', to: '2026-04-01T00:00:00.000Z' };
+
+    expect(MetricsQuerySchema.safeParse({ ...range, interval: 'hour' }).success).toBe(false);
+    expect(MetricsQuerySchema.safeParse({ ...range, interval: 'day' }).success).toBe(true);
+  });
+
+  it('measures an open-ended window against now', () => {
+    const recent = new Date(Date.now() - 1000 * 60 * 60 * 24).toISOString();
+    const ancient = new Date(Date.now() - 1000 * 60 * 60 * 24 * 400).toISOString();
+
+    expect(MetricsQuerySchema.safeParse({ from: recent }).success).toBe(true);
+    expect(MetricsQuerySchema.safeParse({ from: ancient, interval: 'day' }).success).toBe(false);
+  });
+
+  it('rejects a from date in the future when to is omitted', () => {
+    const future = new Date(Date.now() + 1000 * 60 * 60).toISOString();
+
+    expect(MetricsQuerySchema.safeParse({ from: future }).success).toBe(false);
+  });
 });


### PR DESCRIPTION
Closes #17

## State of the issue

Half of it was already done. The `TODO` for time-range parsing is gone and `MetricsQuerySchema` validates `from`/`to` and rejects inverted or oversized windows, as of `5fbf93b`. This PR covers the rest: broadening the analytics, plus two window bugs found while doing it.

## Categories

Auth event types are now rolled up into mutually exclusive categories in `src/lib/authEventCategories.ts`:

`suspicious`, `login`, `registration`, `webauthn`, `oauth`, `magicLink`, `otp`, `totp`, `stepUp`, `token`, `system`, `other`

The previous grouping matched substrings in order, with `type.includes('login')` checked first, so `webauthn_login_success` and `oauth_login_success` were counted as plain logins and their own buckets were never populated. Matching is now prefix-based, and `suspicious` is checked first so a security signal lands in one bucket rather than being split across the surface it came from. A test asserts every type in `AUTH_EVENT_TYPES` maps to a real category and that none fall through to `other`.

## Endpoints

- `/internal/auth-events/timeseries` buckets gain `total` and a `categories` map. `success` and `failed` stay login-only, so the dashboard's `useAuthTimeseries` / `LineChart` / `MiniLineChart` keep working unchanged.
- `/internal/auth-events/grouped` returns the new categories in `summary` plus an `outcomes` roll-up (`success`/`failed`/`suspicious`/`other`). It also stopped calling bare `AuthEvent.findAll()` and counting rows in JS, which loaded every auth event in the table into memory; it now does a grouped count in the database.
- `/internal/auth-events/login-stats` and `/internal/auth-events/summary` accept the same `from`, `to`, and `userId` filters as the other two.

## Window fixes

1. The timeseries validated `from`/`to` and then ignored them when building output: the fill loop was always now-relative (last 24 hours, or last 30 days). A caller asking for January got January's rows filtered but today's buckets back. Buckets now span the requested window.
2. With `interval=day` and no window, the query filtered `created_at >= 24h ago` while filling 30 daily buckets, so 29 of them were structurally always zero.
3. The maximum window is now capped per interval, 31 days for `hour` and 366 days for `day`, instead of a flat 366 days that would have produced 8784 hourly buckets. An open-ended window (`from` with no `to`) is measured against the current time rather than skipping the cap entirely.

## Ripple check

I checked the dependents before changing response shapes. `seamless-auth-admin-dashboard` reads `{bucket, success, failed}` from the timeseries and hits `/auth-events/summary`, `/auth-events/login-stats`, and `/metrics/dashboard`; nothing consumes `/auth-events/grouped`. All changes here are additive to the shapes those hooks read, so no coordinated SDK change is needed.

## Checks

`npm run typecheck`, `npm run lint`, `npm run format:check`, and `npm run coverage` pass (952 passed, 1 skipped). `internalMetrics.ts` is at 97.8% statements, and the new `authEventCategories.ts` is at 100%.