### PR TITLE
feat: add a one-command local stack

### DIFF
--- a/.changeset/olive-moons-shave.md
+++ b/.changeset/olive-moons-shave.md
@@ -1,0 +1,18 @@
+---
+'seamless-auth-api': minor
+---
+
+Add a one-command local stack. `docker compose up` now brings up Postgres and the published API
+image together with development defaults, so trying the project no longer means setting up
+Postgres, writing a `.env`, and generating secrets by hand. Migrations run on first boot, a
+development signing keypair is generated, and the admin console is served at
+`http://localhost:5312/console`. `OWNER_EMAIL` defaults to `owner@example.com`, so signing up with
+that address gives a working admin.
+
+The previous source-built stack moved to `docker-compose.dev.yml` for contributors. It no longer
+requires a `.env` file (one is used when present, and its values win) and it no longer depends on
+a prior `npm run build`, which meant it could not start from a fresh clone. A new `dev:container`
+script runs the watcher without `--env-file`.
+
+Neither compose file pins `container_name` any more, so a leftover container from an older stack
+no longer blocks startup.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,20 +35,30 @@ git clone https://github.com/fells-code/seamless-auth-api.git
 
 ## 2. Run the Seamless Auth Server
 
-```bash
-cd seamless-auth-api
-cp .env.example .env
-```
-
 ### If docker and docker compose are avaliable
 
 ```bash
-docker compose up -d
+cd seamless-auth-api
+docker compose -f docker-compose.dev.yml up
 ```
+
+That builds the API from source, generates development signing keys, runs migrations (creating
+the database on first boot), and starts a watcher that reloads on change. No `.env` file is
+needed: the compose file supplies development defaults. If you do create one, its values win, so
+you can point at a real messaging transport or OAuth provider without editing the compose file.
+
+To run the project rather than work on it, use `docker compose up` instead. That uses the
+published image and also serves the admin console at `/console`, which the dev stack does not
+bundle. See the Docker Quickstart in [README.md](./README.md).
 
 > If you are using docker you can stop here and move on to Step 3.
 
 ### If not using docker
+
+```bash
+cd seamless-auth-api
+cp .env.example .env
+```
 
 Start postgres in whatever way your system does e.g. on mac
 
@@ -62,7 +72,7 @@ brew services start postgresql
 npm install
 
 npm run db:create
-npm run db:migrate
+npm run migrate:up
 
 npm run dev
 ```

--- a/README.md
+++ b/README.md
@@ -334,11 +334,54 @@ This is the fastest way to run **Seamless Auth API** locally using Docker.
 ## Prerequisites
 
 - Docker (Docker Desktop or Docker Engine)
-- A running PostgreSQL instance (local or Docker)
 
 ---
 
-## 1. Pull the public image
+## The whole stack in one command
+
+[`docker-compose.yml`](./docker-compose.yml) brings up Postgres and the API together with
+development defaults, so there is nothing to configure first: no `.env` file, no generated
+secrets, no separate Postgres.
+
+```bash
+docker compose up
+```
+
+That starts the API on `http://localhost:5312`, runs migrations on first boot, generates a
+development signing keypair, and serves the admin console at `http://localhost:5312/console`.
+
+Verify it:
+
+```bash
+curl http://localhost:5312/health/status
+```
+
+To get an admin account, sign up at `/console` with `owner@example.com`. That address is the
+compose file's `OWNER_EMAIL`, so the account is granted the admin role on creation. Override it
+before first boot to use your own:
+
+```bash
+OWNER_EMAIL=you@example.com docker compose up
+```
+
+Other values worth overriding are `API_PORT`, `POSTGRES_PORT`, `APP_ORIGINS`, `ORIGINS`, and
+`SEAMLESS_AUTH_IMAGE` (to pin a specific published tag). Stop the stack with `docker compose down`,
+or `docker compose down -v` to also discard the database.
+
+> The compose defaults are for local development only. They use a well-known shared secret, run
+> with `NODE_ENV=development`, and return OTP codes and magic-link URLs in API responses instead
+> of sending them, which is what makes the stack usable without an email or SMS transport. See
+> [docs/production-operations.md](./docs/production-operations.md) before deploying.
+
+Contributors working on the API itself should use
+[`docker-compose.dev.yml`](./docker-compose.dev.yml) instead, which builds from source and
+hot-reloads. See [CONTRIBUTING.md](./CONTRIBUTING.md).
+
+---
+
+## Running the image yourself
+
+If you already have Postgres and want to run just the API container:
 
 ```bash
 docker pull ghcr.io/fells-code/seamless-auth-api:latest
@@ -350,11 +393,7 @@ Available tags:
 - `nightly` – latest build from `main`
 - `vX.Y.Z` – specific versioned releases
 
----
-
-## 2. Create an environment file
-
-Copy the example and adjust as needed:
+Create an environment file from the example and adjust as needed:
 
 ```bash
 cp .env.example .env
@@ -362,47 +401,21 @@ cp .env.example .env
 
 ⚠️ Do not commit `.env` files. They are ignored by default.
 
----
-
-## 3. Run PostgreSQL (example with Docker)
-
-If you do not already have Postgres running:
-
-```bash
-docker network create seamless-auth-local
-
-docker run -d \
-  --name seamless-auth-postgres \
-  --network seamless-auth-local \
-  -e POSTGRES_USER=myuser \
-  -e POSTGRES_PASSWORD=mypassword \
-  -e POSTGRES_DB=seamless_auth \
-  -p 5432:5432 \
-  postgres:16
-```
-
-The one-off migration command and API container below override `DB_HOST` to the Docker network name.
-
-## 4. Run database migrations
-
-Run migrations before the first boot and after upgrades that include migrations:
+Run migrations before the first boot and after upgrades that include migrations, then start the
+server:
 
 ```bash
 docker run --rm \
   --env-file .env \
-  --network seamless-auth-local \
-  -e DB_HOST=seamless-auth-postgres \
+  -e DB_HOST=host.docker.internal \
   ghcr.io/fells-code/seamless-auth-api:latest \
   npm run migrate:up
 ```
 
-## 5. Run Seamless Auth Server
-
 ```bash
 docker run --rm \
   --env-file .env \
-  --network seamless-auth-local \
-  -e DB_HOST=seamless-auth-postgres \
+  -e DB_HOST=host.docker.internal \
   -p 5312:5312 \
   ghcr.io/fells-code/seamless-auth-api:latest
 ```
@@ -413,10 +426,10 @@ The server will:
 - Start on port `5312`
 - Expose health and authentication endpoints
 
-## 6. Verify it is running
+Verify it is running:
 
 ```bash
-curl http://localhost:5312/health
+curl http://localhost:5312/health/status
 ```
 
 You should receive a healthy response.

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,90 @@
+# Contributor stack: `docker compose -f docker-compose.dev.yml up`.
+#
+# Builds the API from source and hot-reloads on change. Use docker-compose.yml when
+# you only want to run the project rather than work on it: it uses the published
+# image and also serves the admin console at /console, which this file does not
+# bundle.
+#
+# A .env file is optional. When present its values win, so a contributor can point
+# at a different messaging transport or OAuth provider without editing this file.
+
+name: seamless-auth-dev
+
+services:
+  api:
+    build:
+      context: .
+      dockerfile: Dockerfile.dev
+    ports:
+      - '${API_PORT:-5312}:5312'
+    volumes:
+      - .:/app
+      - /app/node_modules
+    # Dockerfile.dev has no build step, so the compiled entrypoint cannot run from a
+    # fresh clone. Generate dev signing keys, migrate (creating the database on first
+    # boot), then run the watcher against the TypeScript sources.
+    entrypoint: ['/bin/sh', '-c']
+    command:
+      - >
+        npx tsx src/scripts/initKeys.ts &&
+        (npm run migrate:up || (npm run db:create && npm run migrate:up)) &&
+        npm run dev:container
+    depends_on:
+      postgres:
+        condition: service_healthy
+    environment:
+      NODE_ENV: development
+
+      APP_NAME: Seamless Auth Local
+      APP_ID: local-dev
+      ISSUER: http://localhost:5312
+      APP_ORIGINS: ${APP_ORIGINS:-http://localhost:3000,http://localhost:5173}
+
+      DEFAULT_ROLES: user
+      AVAILABLE_ROLES: user,admin
+      LOGIN_METHODS: passkey,magic_link,email_otp
+
+      ACCESS_TOKEN_TTL: 30m
+      REFRESH_TOKEN_TTL: 1h
+      RATE_LIMIT: '100'
+      DELAY_AFTER: '50'
+
+      RPID: localhost
+      ORIGINS: ${ORIGINS:-http://localhost:5312,http://localhost:5173,http://localhost:5174}
+      FRONTEND_URL: ${FRONTEND_URL:-http://localhost:5173}
+
+      DB_HOST: postgres
+      DB_PORT: '5432'
+      DB_NAME: seamless_auth
+      DB_USER: seamless
+      DB_PASSWORD: seamless
+      DB_LOGGING: ${DB_LOGGING:-false}
+
+      API_SERVICE_TOKEN: ${API_SERVICE_TOKEN:-local-development-service-token-not-for-deployment}
+      ALLOW_UNCREDENTIALED_DELIVERY_SECRETS: 'true'
+      OWNER_EMAIL: ${OWNER_EMAIL:-owner@example.com}
+      SERVE_ADMIN_DASHBOARD: 'false'
+    env_file:
+      - path: .env
+        required: false
+    restart: unless-stopped
+
+  postgres:
+    image: postgres:16
+    ports:
+      - '${POSTGRES_PORT:-5432}:5432'
+    environment:
+      POSTGRES_USER: seamless
+      POSTGRES_PASSWORD: seamless
+      POSTGRES_DB: seamless_auth
+    healthcheck:
+      test: ['CMD-SHELL', 'pg_isready -U seamless -d seamless_auth']
+      interval: 5s
+      timeout: 5s
+      retries: 10
+    volumes:
+      - pgdata-dev:/var/lib/postgresql/data
+    restart: unless-stopped
+
+volumes:
+  pgdata-dev:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,54 +1,103 @@
+# One-command local stack: `docker compose up`.
+#
+# Brings up Postgres and the published Seamless Auth API image with development
+# defaults, so no .env file and no generated secrets are needed to try the project.
+# The admin console is served by the same container at http://localhost:5312/console.
+#
+# Every value below is a LOCAL DEVELOPMENT default and is not safe for a deployed
+# instance. See docs/configuration.md for the real thing, and
+# docs/production-operations.md before deploying.
+#
+# Contributors working on the API itself want docker-compose.dev.yml instead, which
+# builds from source and hot-reloads.
+
+name: seamless-auth
+
 services:
   api:
-    build:
-      context: .
-      dockerfile: Dockerfile.dev
-    container_name: seamless-auth
+    image: ${SEAMLESS_AUTH_IMAGE:-ghcr.io/fells-code/seamless-auth-api:latest}
     ports:
-      - '5312:5312'
-    volumes:
-      - .:/app
-      - /app/node_modules
-    env_file:
-      - .env
-    environment:
-      DB_HOST: db
+      - '${API_PORT:-5312}:5312'
     depends_on:
       postgres:
         condition: service_healthy
+    environment:
+      # The published image ships NODE_ENV=production, which requires externally
+      # managed JWKS signing keys. Development mode generates a local keypair on
+      # first boot instead.
+      NODE_ENV: development
+
+      APP_NAME: Seamless Auth Local
+      APP_ID: local-dev
+      ISSUER: http://localhost:5312
+      # Callers allowed by CORS. The console is same-origin, so it needs no entry here.
+      APP_ORIGINS: ${APP_ORIGINS:-http://localhost:3000,http://localhost:5173}
+
+      DEFAULT_ROLES: user
+      AVAILABLE_ROLES: user,admin
+      LOGIN_METHODS: passkey,magic_link,email_otp
+
+      ACCESS_TOKEN_TTL: 30m
+      REFRESH_TOKEN_TTL: 1h
+      RATE_LIMIT: '100'
+      DELAY_AFTER: '50'
+
+      # WebAuthn. ORIGINS must include the origin the console is loaded from,
+      # otherwise passkey registration from /console fails origin validation.
+      RPID: localhost
+      ORIGINS: ${ORIGINS:-http://localhost:5312,http://localhost:5173,http://localhost:5174}
+      FRONTEND_URL: ${FRONTEND_URL:-http://localhost:5173}
+
+      DB_HOST: postgres
+      DB_PORT: '5432'
+      DB_NAME: seamless_auth
+      DB_USER: seamless
+      DB_PASSWORD: seamless
+      DB_LOGGING: ${DB_LOGGING:-false}
+
+      # Local-only shared secret. Outside development the API derives the refresh-token
+      # lookup, TOTP encryption, and OAuth state secrets from this when they are unset,
+      # so a deployed instance must set real, separate values.
+      API_SERVICE_TOKEN: ${API_SERVICE_TOKEN:-local-development-service-token-not-for-deployment}
+
+      # Returns OTP codes and magic-link URLs in the response instead of sending them,
+      # so the stack is usable without an email or SMS transport. Ignored when
+      # NODE_ENV=production.
+      ALLOW_UNCREDENTIALED_DELIVERY_SECRETS: 'true'
+
+      # The first account created with this email is granted the admin role, so the
+      # console at /console has a working admin as soon as you sign up.
+      OWNER_EMAIL: ${OWNER_EMAIL:-owner@example.com}
+
+      SERVE_ADMIN_DASHBOARD: 'true'
+
+      # Driving many flows from one host trips the per-IP OTP and magic-link limiters.
+      # Uncomment to turn every auth limiter off while scripting against the stack.
+      # Ignored when NODE_ENV=production.
+      # DISABLE_AUTH_RATE_LIMITS: 'true'
     healthcheck:
-      test: ['CMD', 'node', './healthCheck.js']
+      test: ['CMD', 'node', './dist/healthCheck.js']
       interval: 30s
       timeout: 5s
       retries: 3
+      start_period: 30s
+    restart: unless-stopped
 
   postgres:
     image: postgres:16
-    restart: always
-    container_name: db
     ports:
-      - '5432:5432'
+      - '${POSTGRES_PORT:-5432}:5432'
     environment:
-      POSTGRES_USER: myuser
-      POSTGRES_PASSWORD: mypassword
-      POSTGRES_DB: postgres
+      POSTGRES_USER: seamless
+      POSTGRES_PASSWORD: seamless
+      POSTGRES_DB: seamless_auth
     healthcheck:
-      test: ['CMD-SHELL', 'pg_isready -U myuser -d postgres']
+      test: ['CMD-SHELL', 'pg_isready -U seamless -d seamless_auth']
       interval: 5s
       timeout: 5s
-      retries: 5
+      retries: 10
     volumes:
       - pgdata:/var/lib/postgresql/data
-
-  admin:
-    image: seamless-admin:local
-    container_name: seamless-admin
-    ports:
-      - '5174:80'
-    depends_on:
-      - api
-    environment:
-      API_URL: http://localhost:5312
     restart: unless-stopped
 
 volumes:

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   },
   "scripts": {
     "dev": "tsx watch --env-file .env src/server.ts",
+    "dev:container": "tsx watch src/server.ts",
     "start": "node dist/server.js",
     "build": "tsc",
     "typecheck": "tsc --noEmit",


### PR DESCRIPTION
Closes #93

## State of the issue

A `docker-compose.yml` already existed, but it did not give a one-command stack:

- `env_file: .env` made it hard-fail without a hand-written `.env`, which is exactly the ~41-variable setup the issue is about.
- The `admin` service pointed at `seamless-admin:local`, an image that is not published anywhere and had to be built by hand.
- The `api` service built `Dockerfile.dev`, which has no build step, and then ran `validateEnvs.sh` → `node dist/server.js`. With the repo bind-mounted over `/app`, `dist/` only exists if you already ran `npm run build`, so it could not start from a fresh clone.

## Change

**`docker-compose.yml`** is now the quick-start stack. `docker compose up` brings up Postgres and the published API image with development defaults and no prerequisites: no `.env`, no generated secrets, no separate Postgres. Migrations run on first boot, a development signing keypair is generated, and the admin console is served at `http://localhost:5312/console`.

Notable details:

- The published image ships `NODE_ENV=production`, which requires externally managed JWKS keys, so the compose file sets `NODE_ENV=development` to get the local keypair path.
- `ORIGINS` includes `http://localhost:5312`, since the console is same-origin and passkey registration from `/console` would otherwise fail WebAuthn origin validation.
- `ALLOW_UNCREDENTIALED_DELIVERY_SECRETS=true` returns OTP codes and magic-link URLs in responses, which is what makes the stack usable with no email or SMS transport. It is ignored under `NODE_ENV=production`.
- `OWNER_EMAIL` defaults to `owner@example.com`, so signing up with that address yields a working admin.
- `API_PORT`, `POSTGRES_PORT`, `APP_ORIGINS`, `ORIGINS`, `OWNER_EMAIL`, `API_SERVICE_TOKEN`, and `SEAMLESS_AUTH_IMAGE` are all overridable from the environment.

**`docker-compose.dev.yml`** is the contributor stack: builds from source, hot-reloads. `.env` is now optional (`required: false`) and still wins when present. Its entrypoint generates keys, migrates (creating the database on first boot), then runs the watcher against the TypeScript sources via a new `dev:container` script, which is `dev` without the `--env-file .env` that would fail when no `.env` exists.

Neither file pins `container_name` any more. Compose derives names from the project, so a leftover container from an older stack no longer blocks startup with a name conflict.

## Verification

Both stacks were brought up and torn down for real, not just `docker compose config`.

Quick-start stack: pulled `latest` (v0.5.0), migrations applied, `/health/status` returned `{"message":"System up"}`, `/console/` returned 200, both containers reported healthy. Full auth flow driven end to end with curl:

1. `POST /registration/register` → ephemeral token
2. `GET /otp/generate-email-otp` with `x-seamless-auth-delivery-mode: external` → code returned in the `delivery` payload
3. `POST /otp/verify-email-otp` → 200 with access and refresh tokens
4. `GET /users/me` → `roles: ["user","admin"]`, confirming the `OWNER_EMAIL` grant
5. `GET /admin/users` → 200

Dev stack: built from source, generated keys, applied all migrations including the newest, and came up under `tsx watch` reporting version 0.5.0.

## Docs

The README Docker Quickstart now leads with `docker compose up` and keeps the manual `docker run` path below it for people who already have Postgres. CONTRIBUTING points at the dev file. Two stale commands fixed along the way: `curl .../health` (the route is `/health/status`) and `npm run db:migrate` (the script is `migrate:up`).

## Checks

`npm run typecheck`, `npm run lint`, `npm run format:check`, and `npm run coverage` pass (937 passed, 1 skipped). No source behavior changed, so the suite is unaffected.