### PR TITLE
feat: validate assigned roles and scope the owner grant

### DIFF
--- a/.changeset/chilled-pugs-attack.md
+++ b/.changeset/chilled-pugs-attack.md
@@ -1,0 +1,25 @@
+---
+'seamless-auth-api': minor
+---
+
+Make scoped admin roles assignable and discoverable.
+
+`POST /admin/users` and `PATCH /admin/users/:userId` now reject any role that is not in
+`available_roles` with `400 Invalid roles`, naming the offending roles in `details.roles`.
+Previously a typo like `admin:reed` was accepted and stored, granted nothing because enforcement
+never matches an unlisted role, and reported no error. The match is exact, so wildcards and deeper
+scopes must be listed to be handed out. An empty or unreadable role catalog skips the check rather
+than rejecting every assignment.
+
+`PATCH /admin/users/:userId` previously returned its `400` through a schema that stripped
+`details`, so the caller could not see what was rejected. Both user endpoints now use a validation
+error schema that carries it, and `POST /admin/users` declares its `400` and `409` responses in
+OpenAPI.
+
+The `OWNER_EMAIL` grant is now `admin:write` rather than a bare `admin`, stating the owner's
+authority in the scoped vocabulary. Instances whose `available_roles` lists only `admin` still get
+`admin`, which is equivalent in power, so the grant never becomes a no-op.
+
+`.env.example` now ships `admin:read` and `admin:write` in `AVAILABLE_ROLES` so the console's role
+picker offers read-only admin. `AVAILABLE_ROLES` seeds `available_roles` on first boot only, so
+existing instances need the scoped roles added through the admin system-config endpoints.

--- a/.env.example
+++ b/.env.example
@@ -25,8 +25,11 @@ SERVE_ADMIN_DASHBOARD=true
 
 # Roles assigned to every new user
 DEFAULT_ROLES=user,betaUser
-# Roles that are allowed in the system
-AVAILABLE_ROLES=user,admin,betaUser,team
+# Roles that are allowed in the system. Assigning a role that is not listed here is
+# rejected, because enforcement never matches an unlisted role and the grant would
+# silently do nothing. admin:read is read-only admin; admin:write is full admin.
+# Bare admin remains assignable and is equivalent to admin:write.
+AVAILABLE_ROLES=user,admin,admin:read,admin:write,betaUser,team
 
 # Login methods administrators allow after /login creates a pre-auth session.
 # Supported values: passkey,magic_link,email_otp,phone_otp,oauth

--- a/docs/admin-operations.md
+++ b/docs/admin-operations.md
@@ -13,6 +13,49 @@ Admin routes are split by intent:
 
 The legacy `admin` role remains broad for backwards compatibility.
 
+### Making scoped roles assignable
+
+Enforcement understands scoped roles, but a role can only be handed out if it appears in
+`available_roles`, which is what `GET /roles` returns and what the console's role picker offers.
+Ship `admin:read` and `admin:write` there so read-only admin can be granted without typing a raw
+role string:
+
+```text
+AVAILABLE_ROLES=user,admin,admin:read,admin:write
+```
+
+`AVAILABLE_ROLES` seeds `available_roles` on first boot only. On an instance that is already
+running, add the scoped roles through the admin system-config endpoints instead, since the stored
+row is authoritative from then on. See
+[Environment vs system_config](./configuration.md#environment-vs-system_config).
+
+### Assignment is validated
+
+`POST /admin/users` and `PATCH /admin/users/:userId` reject any role that is not in
+`available_roles` with `400 Invalid roles`, naming the offending roles in `details.roles`.
+
+This exists because enforcement never matches an unlisted role. Before validation, a typo like
+`admin:reed` or `admin:readonly` was stored happily, granted nothing, and reported no error, so
+the mistake only surfaced later as an admin who could not do anything.
+
+The match is exact. Listing `admin:write` does not make `admin:write:users` assignable, and
+wildcards like `admin:*` have to be listed explicitly to be handed out, even though enforcement
+understands them.
+
+If `available_roles` is empty or unreadable, validation is skipped rather than rejecting every
+assignment. It is a guardrail against typos, not an access control, so failing open there cannot
+grant access that enforcement would not already refuse.
+
+### The owner grant
+
+A user who signs up with a configured `OWNER_EMAIL` is granted `admin:write` on account creation,
+not `admin:read`. This is deliberate: the owner paid for the instance and has to be able to run
+it, including granting admin to teammates. Read-only would leave a freshly provisioned tenant with
+no one able to administer it.
+
+Instances whose `available_roles` predates scoped roles and lists only `admin` get `admin`
+instead, which is equivalent in power, so the grant never silently becomes a no-op.
+
 ## Device Replacement Recovery
 
 Administrators with write access can prepare an account for device replacement:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -50,17 +50,17 @@ first boot.
 
 ### Application
 
-| Variable          | Required | Default       | Seeds `system_config` | Notes                                                                                       |
-| ----------------- | -------- | ------------- | --------------------- | ------------------------------------------------------------------------------------------- |
-| `NODE_ENV`        | No       | `development` | No                    | `production` enables stricter checks (JWKS, secrets).                                       |
-| `HOST`            | No       | `0.0.0.0`     | No                    | Bind address.                                                                               |
-| `PORT`            | No       | `5312`        | No                    | Listen port.                                                                                |
-| `APP_NAME`        | Yes      | -             | `app_name`            | Min 3 characters.                                                                           |
-| `APP_ID`          | Yes      | -             | No                    | Stable app identifier.                                                                      |
-| `APP_ORIGINS`     | Yes      | -             | No                    | CORS allowlist for callers of this API (comma-separated). Distinct from WebAuthn `ORIGINS`. |
-| `ISSUER`          | Yes      | -             | No                    | JWT `iss` and issuer URL.                                                                   |
-| `DEFAULT_ROLES`   | Yes      | -             | `default_roles`       | Roles for new users (comma-separated).                                                      |
-| `AVAILABLE_ROLES` | Yes      | -             | `available_roles`     | Roles permitted in the system (comma-separated).                                            |
+| Variable          | Required | Default       | Seeds `system_config` | Notes                                                                                                                                                                                                                               |
+| ----------------- | -------- | ------------- | --------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `NODE_ENV`        | No       | `development` | No                    | `production` enables stricter checks (JWKS, secrets).                                                                                                                                                                               |
+| `HOST`            | No       | `0.0.0.0`     | No                    | Bind address.                                                                                                                                                                                                                       |
+| `PORT`            | No       | `5312`        | No                    | Listen port.                                                                                                                                                                                                                        |
+| `APP_NAME`        | Yes      | -             | `app_name`            | Min 3 characters.                                                                                                                                                                                                                   |
+| `APP_ID`          | Yes      | -             | No                    | Stable app identifier.                                                                                                                                                                                                              |
+| `APP_ORIGINS`     | Yes      | -             | No                    | CORS allowlist for callers of this API (comma-separated). Distinct from WebAuthn `ORIGINS`.                                                                                                                                         |
+| `ISSUER`          | Yes      | -             | No                    | JWT `iss` and issuer URL.                                                                                                                                                                                                           |
+| `DEFAULT_ROLES`   | Yes      | -             | `default_roles`       | Roles for new users (comma-separated).                                                                                                                                                                                              |
+| `AVAILABLE_ROLES` | Yes      | -             | `available_roles`     | Roles permitted in the system (comma-separated). Assigning a role that is not listed is rejected. Include `admin:read` and `admin:write` to offer scoped admin. See [Scoped Admin Roles](./admin-operations.md#scoped-admin-roles). |
 
 ### Auth and tokens
 

--- a/src/controllers/admin.ts
+++ b/src/controllers/admin.ts
@@ -7,6 +7,8 @@
 import { Request, Response } from 'express';
 import { Op, WhereOptions } from 'sequelize';
 
+import { getSystemConfig } from '../config/getSystemConfig.js';
+import { unavailableRoles } from '../lib/scopedRoles.js';
 import { AuthEvent, AuthEventAttributes } from '../models/authEvents.js';
 import { Credential } from '../models/credentials.js';
 import { getSequelize } from '../models/index.js';
@@ -33,6 +35,39 @@ import { redactMetadata } from '../utils/redaction.js';
 import { isValidPhoneNumber, normalizePhoneNumber } from '../utils/utils.js';
 
 const logger = getLogger('admin');
+
+/**
+ * Rejects roles the instance does not list in `available_roles`. Enforcement never
+ * matches an off-list role, so without this a typo like `admin:reed` is stored,
+ * grants nothing, and reports no error.
+ *
+ * An unreadable or empty catalog skips the check rather than rejecting everything.
+ * This is a typo guardrail, not an access control, so failing open cannot grant
+ * access that `roleGrantsAccess` would not already refuse, and it keeps a config
+ * glitch from locking every role assignment out.
+ */
+async function rejectUnavailableRoles(roles: string[] | undefined, res: Response) {
+  if (!roles?.length) return false;
+
+  const available = (await getSystemConfig())?.available_roles ?? [];
+
+  if (!available.length) {
+    logger.warn('available_roles is empty; skipping role assignment validation');
+    return false;
+  }
+
+  const unavailable = unavailableRoles(roles, available);
+
+  if (!unavailable.length) return false;
+
+  res.status(400).json({
+    error: 'Invalid roles',
+    message: `Roles not available on this instance: ${unavailable.join(', ')}`,
+    details: { roles: unavailable, availableRoles: available },
+  });
+
+  return true;
+}
 
 export const getUsers = async (req: ServiceRequest, res: Response) => {
   const { limit = 50, offset = 0, search } = req.query;
@@ -92,6 +127,10 @@ export const createUser = async (req: Request, res: Response) => {
       error: 'Invalid payload',
       details: { phone: 'Invalid phone number' },
     });
+  }
+
+  if (await rejectUnavailableRoles(roles, res)) {
+    return;
   }
 
   try {
@@ -159,6 +198,10 @@ export const updateUser = async (req: ServiceRequest, res: Response) => {
       error: 'Invalid update payload',
       details: parsed.error,
     });
+  }
+
+  if (await rejectUnavailableRoles(parsed.data.roles, res)) {
+    return;
   }
 
   try {

--- a/src/lib/ownerAdmin.ts
+++ b/src/lib/ownerAdmin.ts
@@ -17,7 +17,15 @@
  * deployments are unaffected.
  */
 
-const ADMIN_ROLE = 'admin';
+/**
+ * The owner is granted full admin write, not read-only: they paid for the instance
+ * and must be able to run it, including granting admin to teammates. The grant is
+ * expressed as `admin:write` so the owner's authority is stated in the scoped
+ * vocabulary rather than relying on the broad legacy role. Instances that predate
+ * scoped roles and list only `admin` still get `admin`, which is equivalent in
+ * power, so the grant never silently becomes a no-op.
+ */
+const OWNER_ADMIN_ROLES: readonly string[] = ['admin:write', 'admin'];
 
 function ownerEmails(): Set<string> {
   return new Set(
@@ -36,9 +44,10 @@ export function isOwnerEmail(email: string | null | undefined): boolean {
 }
 
 /**
- * Returns `baseRoles` with the admin role appended when `email` is a configured
- * owner email and the instance lists admin as an available role. Idempotent, and
- * a no-op when `OWNER_EMAIL` is unset or admin is not an available role.
+ * Returns `baseRoles` with the owner's admin role appended when `email` is a
+ * configured owner email and the instance lists one of the admin roles as
+ * available. Idempotent, and a no-op when `OWNER_EMAIL` is unset or no admin role
+ * is available.
  */
 export function withOwnerAdminRole(
   baseRoles: string[],
@@ -48,8 +57,12 @@ export function withOwnerAdminRole(
   if (!isOwnerEmail(email)) {
     return baseRoles;
   }
-  if (!availableRoles.includes(ADMIN_ROLE) || baseRoles.includes(ADMIN_ROLE)) {
+
+  if (baseRoles.some((role) => OWNER_ADMIN_ROLES.includes(role))) {
     return baseRoles;
   }
-  return [...baseRoles, ADMIN_ROLE];
+
+  const grant = OWNER_ADMIN_ROLES.find((role) => availableRoles.includes(role));
+
+  return grant ? [...baseRoles, grant] : baseRoles;
 }

--- a/src/lib/scopedRoles.ts
+++ b/src/lib/scopedRoles.ts
@@ -51,6 +51,19 @@ export function roleGrantsAccess(grantedRole: string, requiredRole: string) {
   );
 }
 
+/**
+ * Returns the assigned roles that are not in the instance's `available_roles`.
+ *
+ * The match is exact rather than scope-aware: listing `admin:write` does not make
+ * `admin:write:users` assignable. Enforcement (`roleGrantsAccess`) never matches an
+ * off-list role, so accepting one would store a grant that silently does nothing.
+ */
+export function unavailableRoles(assignedRoles: string[], availableRoles: string[]): string[] {
+  const available = new Set(availableRoles.map(normalizeRole));
+
+  return assignedRoles.filter((role) => !available.has(normalizeRole(role)));
+}
+
 export function hasScopedRole(grantedRoles: unknown, requiredRoles: string | string[]) {
   if (!Array.isArray(grantedRoles)) {
     return false;

--- a/src/routes/admin.routes.ts
+++ b/src/routes/admin.routes.ts
@@ -41,6 +41,7 @@ import {
 import {
   AdminUserAnomaliesResponseSchema,
   AdminUserDetailResponseSchema,
+  AdminValidationErrorSchema,
   DeviceReplacementRecoveryResponseSchema,
   UserResponseSchema,
 } from '../schemas/admin.responses.js';
@@ -279,6 +280,8 @@ adminRouter.post(
       body: CreateUserSchema,
       response: {
         201: UserResponseSchema,
+        400: AdminValidationErrorSchema,
+        409: InternalErrorSchema,
       },
     },
   },
@@ -316,7 +319,7 @@ adminRouter.patch(
 
       response: {
         200: UserResponseSchema,
-        400: InternalErrorSchema,
+        400: AdminValidationErrorSchema,
         404: InternalErrorSchema,
       },
     },

--- a/src/schemas/admin.responses.ts
+++ b/src/schemas/admin.responses.ts
@@ -33,3 +33,11 @@ export const AdminUserAnomaliesResponseSchema = z.object({
   relatedIps: z.array(z.string()),
   relatedAgents: z.array(z.string()),
 });
+
+// Validation failures on the user endpoints carry a `details` payload naming what was
+// rejected, which a plain error schema would strip before it reached the caller.
+export const AdminValidationErrorSchema = z.object({
+  error: z.string(),
+  message: z.string().optional(),
+  details: z.record(z.string(), z.unknown()).optional(),
+});

--- a/tests/integration/admin/admin.spec.ts
+++ b/tests/integration/admin/admin.spec.ts
@@ -19,6 +19,8 @@ import {
 } from '../../../src/controllers/admin.js';
 import { buildCredential } from '../../factories/credentialFactory.js';
 import { buildSession } from '../../factories/sessionFactory.js';
+import { getSystemConfig } from '../../../src/config/getSystemConfig.js';
+import { buildSystemConfig } from '../../factories/systemConfigFactory.js';
 
 let app: Application;
 
@@ -374,6 +376,47 @@ describe('POST /admin/users', () => {
     );
   });
 
+  it('rejects a role that is not in available_roles', async () => {
+    (getSystemConfig as any).mockResolvedValue(
+      buildSystemConfig({ available_roles: ['user', 'admin', 'admin:read', 'admin:write'] }),
+    );
+
+    const res = await request(app)
+      .post('/admin/users')
+      .send({ email: 'test@example.com', roles: ['admin:reed'] });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('Invalid roles');
+    expect(res.body.details.roles).toEqual(['admin:reed']);
+    expect(User.create).not.toHaveBeenCalled();
+  });
+
+  it('accepts a scoped role that is in available_roles', async () => {
+    (getSystemConfig as any).mockResolvedValue(
+      buildSystemConfig({ available_roles: ['user', 'admin', 'admin:read', 'admin:write'] }),
+    );
+    (User.findOne as any).mockResolvedValue(null);
+    (User.create as any).mockResolvedValue(buildUser({ roles: ['admin:read'] }));
+
+    const res = await request(app)
+      .post('/admin/users')
+      .send({ email: 'test@example.com', roles: ['admin:read'] });
+
+    expect(res.status).toBe(201);
+  });
+
+  it('skips validation when the role catalog is empty', async () => {
+    (getSystemConfig as any).mockResolvedValue(buildSystemConfig({ available_roles: [] }));
+    (User.findOne as any).mockResolvedValue(null);
+    (User.create as any).mockResolvedValue(buildUser({ roles: ['anything'] }));
+
+    const res = await request(app)
+      .post('/admin/users')
+      .send({ email: 'test@example.com', roles: ['anything'] });
+
+    expect(res.status).toBe(201);
+  });
+
   it('rejects scoped roles with invalid separators', async () => {
     const res = await request(app)
       .post('/admin/users')
@@ -434,6 +477,20 @@ describe('PATCH /admin/users/:userId', () => {
 
     expect(res.status).toBe(200);
     expect(user.update).toHaveBeenCalledWith({ roles: ['admin:write'] });
+  });
+
+  it('rejects an update to a role that is not in available_roles', async () => {
+    (getSystemConfig as any).mockResolvedValue(
+      buildSystemConfig({ available_roles: ['user', 'admin', 'admin:read', 'admin:write'] }),
+    );
+
+    const res = await request(app)
+      .patch('/admin/users/user-1')
+      .send({ roles: ['admin:readonly'] });
+
+    expect(res.status).toBe(400);
+    expect(res.body.details.roles).toEqual(['admin:readonly']);
+    expect(User.findByPk).not.toHaveBeenCalled();
   });
 
   it('clears phone state when phone is removed', async () => {

--- a/tests/unit/lib/ownerAdmin.spec.ts
+++ b/tests/unit/lib/ownerAdmin.spec.ts
@@ -51,7 +51,14 @@ describe('ownerAdmin', () => {
       expect(withOwnerAdminRole(DEFAULTS, 'owner@example.com', AVAILABLE)).toEqual(DEFAULTS);
     });
 
-    it('grants admin to a matching owner email', () => {
+    it('grants admin:write to a matching owner email', () => {
+      process.env.OWNER_EMAIL = 'owner@example.com';
+      expect(
+        withOwnerAdminRole(DEFAULTS, 'owner@example.com', [...AVAILABLE, 'admin:write']),
+      ).toEqual([...DEFAULTS, 'admin:write']);
+    });
+
+    it('falls back to admin when the instance predates scoped roles', () => {
       process.env.OWNER_EMAIL = 'owner@example.com';
       expect(withOwnerAdminRole(DEFAULTS, 'owner@example.com', AVAILABLE)).toEqual([
         ...DEFAULTS,
@@ -71,10 +78,17 @@ describe('ownerAdmin', () => {
       );
     });
 
-    it('is idempotent when admin is already present', () => {
+    it('is idempotent when an admin role is already present', () => {
       process.env.OWNER_EMAIL = 'owner@example.com';
-      const base = ['user', 'admin'];
-      expect(withOwnerAdminRole(base, 'owner@example.com', AVAILABLE)).toEqual(base);
+
+      for (const base of [
+        ['user', 'admin'],
+        ['user', 'admin:write'],
+      ]) {
+        expect(
+          withOwnerAdminRole(base, 'owner@example.com', [...AVAILABLE, 'admin:write']),
+        ).toEqual(base);
+      }
     });
 
     it('does not mutate the input array', () => {

--- a/tests/unit/lib/scopedRoles.spec.ts
+++ b/tests/unit/lib/scopedRoles.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { hasScopedRole, roleGrantsAccess } from '../../../src/lib/scopedRoles.js';
+import { hasScopedRole, roleGrantsAccess, unavailableRoles } from '../../../src/lib/scopedRoles.js';
 
 describe('scoped roles', () => {
   it('matches exact roles', () => {
@@ -46,5 +46,33 @@ describe('scoped roles', () => {
 
   it('coerces a single required role and ignores non-string granted entries', () => {
     expect(hasScopedRole(['admin', 42], 'admin:read')).toBe(true);
+  });
+});
+
+describe('unavailableRoles', () => {
+  const AVAILABLE = ['user', 'admin', 'admin:read', 'admin:write'];
+
+  it('returns nothing when every role is available', () => {
+    expect(unavailableRoles(['user', 'admin:read'], AVAILABLE)).toEqual([]);
+  });
+
+  it('returns the roles that are not listed', () => {
+    expect(unavailableRoles(['user', 'admin:reed', 'betaUser'], AVAILABLE)).toEqual([
+      'admin:reed',
+      'betaUser',
+    ]);
+  });
+
+  it('matches exactly rather than by scope prefix', () => {
+    expect(unavailableRoles(['admin:write:users'], AVAILABLE)).toEqual(['admin:write:users']);
+    expect(unavailableRoles(['admin:*'], AVAILABLE)).toEqual(['admin:*']);
+  });
+
+  it('ignores surrounding whitespace on both sides', () => {
+    expect(unavailableRoles(['  admin:read  '], ['  admin:read'])).toEqual([]);
+  });
+
+  it('treats an empty catalog as allowing nothing', () => {
+    expect(unavailableRoles(['user'], [])).toEqual(['user']);
   });
 });


### PR DESCRIPTION
Closes #111

## State of the issue

Verified against current code before starting. The issue's "what already works" section holds: `src/lib/scopedRoles.ts` implements the matching rules, `requireAdmin('read'|'write')` is applied across the admin surface, and the create/update endpoints already accept a scoped string. All three gaps were still open.

## 1. Assignment is now validated

`POST /admin/users` and `PATCH /admin/users/:userId` reject any role not in `available_roles` with `400 Invalid roles`, naming the offending roles in `details.roles`.

Before this, `RoleNameSchema` checked only the character pattern and the handlers wrote `roles` straight through, so `admin:reed` was stored happily, granted nothing (because `roleGrantsAccess` never matches an unlisted role), and reported no error. The mistake only surfaced later as an admin who could not do anything.

Details worth flagging for review:

- **The match is exact.** Listing `admin:write` does not make `admin:write:users` assignable, and `admin:*` must be listed explicitly to be handed out even though enforcement understands wildcards. Predictable beats clever here, and it is documented.
- **An empty or unreadable catalog skips the check** rather than rejecting everything. This is a typo guardrail, not an access control, so failing open cannot grant access enforcement would refuse anyway, and it stops a config glitch from locking out every role assignment.
- **No grandfathering.** Per your call, any off-list role is rejected, including one a user already holds. A tenant that assigned an off-list role (say a `betaUser` flag their app reads) that is not in `available_roles` will get a `400` the next time that user is edited. The fix is to add the role to `available_roles`, and the error names exactly which role to add.

## 2. Scoped roles are discoverable

`.env.example` now ships `AVAILABLE_ROLES=user,admin,admin:read,admin:write,betaUser,team`, so a fresh instance offers read-only admin in `GET /roles` and therefore in the console's role picker. Bare `admin` stays assignable.

`AVAILABLE_ROLES` seeds `available_roles` on first boot only, so **existing instances will not pick this up**. They need the scoped roles added through the admin system-config endpoints. Documented in `docs/admin-operations.md`.

## 3. The owner grant is a recorded decision

`withOwnerAdminRole` now grants `admin:write` rather than a bare `admin`, stating the owner's authority in the scoped vocabulary. The reasoning is written into `src/lib/ownerAdmin.ts` and the docs: the owner paid for the instance and must be able to run it, including granting admin to teammates, so read-only would leave a fresh tenant with nobody able to administer it.

The switch has a trap I handled: `withOwnerAdminRole` only grants a role the instance lists as available, so on a tenant whose `available_roles` is still `user,admin` the new grant would have silently become a no-op and owners would stop getting admin. The grant now prefers `admin:write` and falls back to `admin`, which is equivalent in power.

## Contract impact

This is contract-affecting, so per the ripple protocol:

- **New `400`** on `POST /admin/users` and `PATCH /admin/users/:userId`. Callers that previously always succeeded with an off-list role now get an error.
- **`PATCH /admin/users/:userId` returned its `400` through `InternalErrorSchema`**, which stripped `details` before it reached the caller, so the rejected role was invisible. Both user endpoints now use `AdminValidationErrorSchema`, which carries `details`. `POST /admin/users` also declares its `400` and `409` in OpenAPI, which it did not before.

`seamless-auth-admin-dashboard` is the consumer. Its `apiFetch` surfaces `fields.error ?? fields.message` on a `400`, so an operator sees "Invalid roles" in a toast. That satisfies "fails loudly", but the specifics live in `message`. An optional dashboard follow-up would prefer the longer `message` for validation statuses so the operator sees which role was rejected. No SDK change is required.

## Cross-repo follow-ups

- `seamless-terraform-service`: `AVAILABLE_ROLES` in `trial-jobs/service.tf` and `paid-jobs/service.tf` needs `admin:read,admin:write` added for provisioned tenants to offer them. Not done here.
- The compose files from #93 (PR #117) still set `AVAILABLE_ROLES: user,admin`. `docker-compose.dev.yml` does not exist on this branch, so aligning both is a small follow-up once these two merge.

## Checks

`npm run typecheck`, `npm run lint`, `npm run format:check`, and `npm run coverage` pass (947 passed, 1 skipped). `scopedRoles.ts` and `ownerAdmin.ts` are at 100%. New tests cover the rejection on both endpoints, acceptance of a listed scoped role, the empty-catalog skip, exact-match semantics, and the owner grant's fallback.