### PR TITLE
feat: give /login a single rejection shape and record security posture

### DIFF
--- a/.changeset/eighty-pans-repeat.md
+++ b/.changeset/eighty-pans-repeat.md
@@ -1,0 +1,24 @@
+---
+'seamless-auth-api': minor
+---
+
+Give `POST /login` a single rejection shape and record the server's security posture.
+
+Every `/login` failure now answers an identical `401 { "error": "Not Allowed" }`. An unknown
+identifier, an unverified account, an account with no permitted continuation method, and a failure
+to mint the pre-auth token previously produced three distinguishable bodies, so an unauthenticated
+caller could tell which case it had hit. The reason is still recorded in the `login_failed` auth
+event metadata, so operators keep the detail.
+
+The two identifier-lookup failure branches, which fire when the database is unreachable rather
+than when the identifier is unknown, answered `401` on the email path and `403` on the phone path.
+Both now answer `500 { "error": "Server error" }`, so an outage is reported as an outage instead
+of as a failed login.
+
+`loginMethods` is unchanged on the success response. Removing it buys no enumeration benefit until
+unknown identifiers also receive a decoy token, and dropping it early would degrade legitimate
+clients to a default method list.
+
+New `docs/security-posture.md` states the deliberate tradeoffs and their mitigating controls: the
+residual enumeration on `/login` and what closing it would take, ephemeral token replay within its
+5 minute TTL, email and phone being plaintext at rest, and the per-deployment `aud` scheme.

--- a/.gitignore
+++ b/.gitignore
@@ -44,4 +44,5 @@ docs/*
 !docs/extending.md
 !docs/oauth.md
 !docs/production-operations.md
+!docs/security-posture.md
 !docs/webauthn-prf.md

--- a/README.md
+++ b/README.md
@@ -477,6 +477,7 @@ See [CONTRIBUTING.md](./CONTRIBUTING.md).
 - [docs/webauthn-prf.md](./docs/webauthn-prf.md) for PRF-capable passkey usage
 - [docs/admin-operations.md](./docs/admin-operations.md) for scoped admin and recovery operations
 - [docs/production-operations.md](./docs/production-operations.md) for production deployment guidance
+- [docs/security-posture.md](./docs/security-posture.md) for deliberate security tradeoffs (enumeration, token replay, data at rest)
 
 ## Security
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -58,6 +58,12 @@ Seamless Auth API uses modern identity and crypto best practices, but you should
 - Use HTTPS and secure cookie settings in production
 - Isolate your instance from untrusted networks
 
+Some behaviors are deliberate tradeoffs rather than oversights, including the residual user
+enumeration on `/login`, ephemeral token replay within its TTL, and email and phone being stored
+in plaintext. Each is stated with its reasoning and mitigating controls in
+[docs/security-posture.md](./docs/security-posture.md). Please read it before reporting one of
+those as a vulnerability.
+
 ---
 
 Thank you for helping keep Seamless Auth API secure!

--- a/docs/security-posture.md
+++ b/docs/security-posture.md
@@ -1,0 +1,114 @@
+# Security Posture
+
+Decisions that are deliberate tradeoffs rather than open bugs. Each one states what the server
+does, why, and what would change it. If you are looking for how to configure the server, see
+[configuration.md](./configuration.md); for operational hardening, see
+[production-operations.md](./production-operations.md).
+
+## User enumeration on `/login`
+
+**Posture: partially mitigated, deliberately.** A failed `/login` does not say why it failed. A
+successful one still proves the identifier exists.
+
+`POST /login` answers one identical `401 { "error": "Not Allowed" }` for every rejection:
+
+- an identifier that matches no account,
+- an account that exists but is not verified,
+- an account with no permitted continuation method under the current login policy,
+- a failure to mint the pre-auth token.
+
+Previously these produced three distinguishable bodies, so an unauthenticated caller could tell
+which case it had hit. The reason is still recorded in the `login_failed` auth event metadata, so
+operators keep the detail; it is simply no longer disclosed to the caller.
+
+### What is still observable
+
+A valid, verified identifier gets `200` with an ephemeral token, so `/login` still distinguishes
+"this account exists and can sign in" from everything else. Some of this is inherent to
+passwordless login: the client legitimately needs to know which continuation methods are available
+before it can render anything.
+
+Closing it fully means returning `200` with a decoy ephemeral token for unknown identifiers, and
+making all 15 ephemeral-auth continuation endpoints behave identically for a decoy, including
+making OTP and magic-link sends appear to succeed. Otherwise the oracle just moves one step later.
+That is tracked in [issue #120](https://github.com/fells-code/seamless-auth-api/issues/120); it is
+a redesign of the pre-auth surface, not a patch.
+
+Two other signals are accepted on purpose:
+
+- **Account lockout** answers `423` with `retryAfterSeconds`. Only a real account can be locked,
+  so this discloses existence, but it requires prior failed attempts against that specific
+  account, and suppressing it would leave a locked-out user with no way to understand what
+  happened.
+- **A malformed identifier** answers `400`. This does not depend on whether any account exists, so
+  it is not an enumeration signal.
+
+### Mitigating controls
+
+Enumeration at scale is bounded by the rate limiters in
+[`src/middleware/rateLimit.ts`](../src/middleware/rateLimit.ts) and by the lockout policy
+(`LOCKOUT_POLICY`). Every attempt is recorded as an auth event, so bulk probing is visible in
+`/internal/auth-events` and the `suspicious` metrics category.
+
+### Note on 401 vs 403
+
+Automated scans tend to flag `/login` for answering `401` on one path and `403` on another. Those
+were the database-error branches, where the identifier lookup itself threw, not the not-found path.
+Both now answer `500 { "error": "Server error" }`, so a database outage is reported as an outage
+rather than as a failed login, and the two identifier branches agree.
+
+## Ephemeral (pre-auth) token replay
+
+**Posture: accepted, with mitigating controls named.**
+
+Ephemeral tokens ([`src/lib/token.ts`](../src/lib/token.ts)) are validated by signature and expiry
+but are not single-use, so a leaked one can be replayed until it expires.
+
+The window is 5 minutes. Every continuation endpoint that accepts an ephemeral token is behind the
+OTP, magic-link, or registration rate limiters, which are keyed per IP and per identity, so replay
+cannot be used to generate OTPs in bulk. An ephemeral token also cannot be exchanged for anything
+on its own: it authorizes a continuation step that still requires the OTP code, the magic-link
+token, or a WebAuthn assertion.
+
+Making them single-use would mean tracking a `jti` in a short-lived store and consuming it on first
+successful continuation. That adds server-side state to a deliberately stateless design and
+introduces a failure mode where a dropped response leaves a user unable to retry a step they
+legitimately started. Given the short TTL and the limiters, that trade was not judged worthwhile.
+
+Revisit this if the ephemeral TTL is ever lengthened, or if a continuation endpoint is added that
+has a side effect worth replaying on its own.
+
+## Email and phone at rest
+
+**Posture: plaintext, by design, and documented as such.**
+
+`users.email` and `users.phone` are stored as plaintext columns
+([`src/models/users.ts`](../src/models/users.ts)). They are lookup keys: `/login`, registration,
+and admin search all query by them directly.
+
+Encrypting them at rest would require deterministic encryption or a blind-index column so those
+lookups still work, plus a backfill migration and a key-rotation story. That is a scoped project
+rather than a configuration flag, and it is not currently planned.
+
+Operators who need these fields encrypted at rest should use database-level encryption
+(for example RDS/Aurora storage encryption, or full-disk encryption), which protects the same data
+without breaking lookups.
+
+## Token audience
+
+**Posture: `aud` is the deployment's own issuer URL.**
+
+Access, refresh, and ephemeral tokens are all signed with `aud` equal to `ISSUER`
+([`src/lib/token.ts`](../src/lib/token.ts)). Verifiers enforce it: the Seamless adapter checks
+`aud === audience`, and the deployment contract requires the adopter's `audience` to equal its
+`authServerUrl`, which is byte-identical to `ISSUER`.
+
+A per-deployment audience is deliberate. A single global literal such as `seamless-auth` would make
+every tenant share one audience string, so a token minted by one instance would satisfy an audience
+check on another.
+
+The internal service-token path
+([`src/middleware/authenticateServiceToken.ts`](../src/middleware/authenticateServiceToken.ts))
+does use `aud: seamless-auth` with `iss: seamless-portal-api`. That is a different token family:
+machine-to-machine credentials minted by the portal API, not user tokens minted here. The two
+schemes are intentionally separate, and neither verifier accepts the other's tokens.

--- a/src/controllers/authentication.ts
+++ b/src/controllers/authentication.ts
@@ -37,6 +37,32 @@ import {
 
 const logger = getLogger('authentication');
 
+/**
+ * The single rejection every failed `/login` takes, whatever the reason.
+ *
+ * An unknown identifier, an unverified account, and an account with no permitted
+ * continuation method used to answer with three distinguishable bodies, which told an
+ * unauthenticated caller which of the three it had hit. The reason is still recorded as
+ * auth-event metadata for operators; it is just no longer disclosed to the caller.
+ *
+ * This does not make `/login` non-enumerable on its own: a valid identifier still gets a
+ * 200 with an ephemeral token. Closing that requires decoy tokens across the continuation
+ * endpoints. See docs/security-posture.md.
+ */
+function rejectLogin(res: Response) {
+  return res.status(401).json({ error: 'Not Allowed' });
+}
+
+/**
+ * The identifier lookup threw, meaning the database is unreachable rather than the
+ * identifier being unknown. The email branch answered 401 and the phone branch 403 for
+ * the same failure, which is what automated scans flag on this handler. Both now report
+ * a server error, so an outage is not reported to the caller as a failed login.
+ */
+function rejectLoginLookupFailure(res: Response) {
+  return res.status(500).json({ error: 'Server error' });
+}
+
 export const login = async (req: Request, res: Response) => {
   // For the initial login step, user either passes in an email or a phone number
   const { identifier, passkeyAvailable } = req.body;
@@ -66,14 +92,14 @@ export const login = async (req: Request, res: Response) => {
       });
       identifierType = 'email';
     } catch {
-      logger.error('Failed to find user');
+      logger.error('Failed to look up user by email');
       await AuthEventService.log({
         userId: null,
         type: 'login_failed',
         req,
-        metadata: { reason: 'No user found for identifier' },
+        metadata: { reason: 'Identifier lookup failed' },
       });
-      return res.status(401).json({ message: 'Not allowed' });
+      return rejectLoginLookupFailure(res);
     }
   } else if (isValidPhoneNumber(identifier) && normalizedIdentifier) {
     try {
@@ -82,14 +108,14 @@ export const login = async (req: Request, res: Response) => {
       });
       identifierType = 'phone';
     } catch {
-      logger.error('Failed to find user');
+      logger.error('Failed to look up user by phone');
       await AuthEventService.log({
         userId: null,
         type: 'login_failed',
         req,
-        metadata: { reason: 'No user found for identifier' },
+        metadata: { reason: 'Identifier lookup failed' },
       });
-      return res.status(403).json({ error: 'Not allowed' });
+      return rejectLoginLookupFailure(res);
     }
   } else {
     logger.error('Invalid login identifier');
@@ -111,7 +137,7 @@ export const login = async (req: Request, res: Response) => {
         req,
         metadata: { reason: 'No user found for identifier' },
       });
-      return res.status(401).json({ error: 'Not Allowed' });
+      return rejectLogin(res);
     }
 
     if (await rejectIfUserLocked({ userId: user.id, req, res })) {
@@ -130,7 +156,7 @@ export const login = async (req: Request, res: Response) => {
         metadata: { reason: 'Unverified but valid user' },
       });
 
-      return res.status(401).json({ error: 'Login failed. Need to verify.' });
+      return rejectLogin(res);
     }
 
     const [credential, loginPolicy] = await Promise.all([
@@ -152,7 +178,7 @@ export const login = async (req: Request, res: Response) => {
         req,
         metadata: { reason: 'No allowed login methods available' },
       });
-      return res.status(401).json({ error: 'No available login methods' });
+      return rejectLogin(res);
     }
 
     if (token) {
@@ -173,7 +199,7 @@ export const login = async (req: Request, res: Response) => {
         ttl: parseDurationToSeconds(access_token_ttl || '15m'),
       });
     }
-    return res.status(401).json({ error: 'Login failed.' });
+    return rejectLogin(res);
   } catch (error: unknown) {
     if (error instanceof Error) {
       logger.error(`Error during login: ${error.message}`);

--- a/tests/integration/authentication/authentication.spec.ts
+++ b/tests/integration/authentication/authentication.spec.ts
@@ -109,7 +109,7 @@ describe('POST /login', () => {
     });
 
     expect(res.status).toBe(401);
-    expect(res.body.error).toBe('No available login methods');
+    expect(res.body).toEqual({ error: 'Not Allowed' });
   });
 
   it('logs in successfully', async () => {
@@ -185,15 +185,16 @@ describe('POST /login', () => {
     expect(User.findOne).toHaveBeenCalledWith({ where: { phone: expect.any(String) } });
   });
 
-  it('rejects when the email lookup throws', async () => {
+  it('reports a server error when the email lookup throws', async () => {
     (User.findOne as any).mockRejectedValue(new Error('db down'));
 
     const res = await request(app).post('/login').send({ identifier: 'test@example.com' });
 
-    expect(res.status).toBe(401);
+    expect(res.status).toBe(500);
+    expect(res.body.error).toBe('Server error');
   });
 
-  it('returns 401 when the ephemeral token cannot be signed', async () => {
+  it('rejects uniformly when the ephemeral token cannot be signed', async () => {
     (User.findOne as any).mockResolvedValue(buildUser({ verified: true }));
     (Credential.findOne as any).mockResolvedValue({});
     (signEphemeralToken as any).mockResolvedValue(null);
@@ -202,7 +203,7 @@ describe('POST /login', () => {
     const res = await request(app).post('/login').send({ identifier: 'test@example.com' });
 
     expect(res.status).toBe(401);
-    expect(res.body.error).toBe('Login failed.');
+    expect(res.body).toEqual({ error: 'Not Allowed' });
   });
 
   it('returns 500 when the post-identifier flow throws', async () => {
@@ -227,13 +228,44 @@ describe('POST /login', () => {
     expect(res.body.error).toBe('Server error');
   });
 
-  it('rejects when the phone lookup throws', async () => {
+  it('reports a server error when the phone lookup throws, matching the email branch', async () => {
     (User.findOne as any).mockRejectedValue(new Error('db down'));
 
     const res = await request(app).post('/login').send({ identifier: '+14155552671' });
 
-    expect(res.status).toBe(403);
-    expect(res.body.error).toBe('Not allowed');
+    expect(res.status).toBe(500);
+    expect(res.body.error).toBe('Server error');
+  });
+
+  it('answers identically for unknown, unverified, and no-method identifiers', async () => {
+    const responses: { status: number; body: unknown }[] = [];
+
+    // Unknown identifier.
+    (User.findOne as any).mockResolvedValue(null);
+    responses.push(await request(app).post('/login').send({ identifier: 'nobody@example.com' }));
+
+    // Known but unverified.
+    (User.findOne as any).mockResolvedValue(buildUser({ verified: false }));
+    (signEphemeralToken as any).mockResolvedValue('token');
+    responses.push(
+      await request(app).post('/login').send({ identifier: 'unverified@example.com' }),
+    );
+
+    // Verified, but the policy leaves no permitted continuation method.
+    (User.findOne as any).mockResolvedValue(buildUser({ verified: true }));
+    (Credential.findOne as any).mockResolvedValue(null);
+    (getSystemConfig as any).mockResolvedValue({
+      access_token_ttl: '15m',
+      login_methods: ['passkey'],
+      passkey_login_fallback_enabled: false,
+    });
+    responses.push(await request(app).post('/login').send({ identifier: 'nomethods@example.com' }));
+
+    const shapes = responses.map((res) => ({ status: res.status, body: res.body }));
+
+    expect(shapes[0]).toEqual({ status: 401, body: { error: 'Not Allowed' } });
+    expect(shapes[1]).toEqual(shapes[0]);
+    expect(shapes[2]).toEqual(shapes[0]);
   });
 
   it('rejects login for a locked account', async () => {


### PR DESCRIPTION
Closes #58
Closes #59
Closes #46
Closes #109

These four are bundled because their resolutions are one document. #58 also carries a code change; the other three resolve as recorded decisions, and splitting them into four PRs would mean four PRs editing the same new file.

## #58 — login enumeration (code + docs)

`POST /login` now answers one identical `401 { "error": "Not Allowed" }` for every rejection: unknown identifier, unverified account, no permitted continuation method, and a failed token signing. Previously these produced three distinguishable bodies, including a `"Login failed. Need to verify."` that confirmed an account existed. The reason still goes into the `login_failed` auth event metadata, so operators lose nothing.

**Scope note.** This does not make `/login` non-enumerable, and the doc says so plainly. A valid identifier still gets `200` with a token. Closing that needs decoy tokens plus non-leaking behavior across all 15 ephemeral-auth endpoints, which is a redesign of the pre-auth surface. Opened as #120 with the design questions worked out.

**`loginMethods` stays.** I had proposed dropping it. On inspection that is net-negative right now: it buys no enumeration benefit until decoys exist (the `401` already answers the question), and both consumers fall back to a default method list when it is absent, so legitimate users would be offered methods the policy disallows. It moves in #120 where it actually pays off.

**One status-code change.** The two identifier-lookup `catch` branches fire when the database is unreachable, not when the identifier is unknown. They answered `401` on the email path and `403` on the phone path for the identical failure, which is the 401-vs-403 difference automated scans flag here. Both now answer `500 { "error": "Server error" }`, so an outage is reported as an outage rather than as a failed login. This is the only status-code change in the PR.

### Ripple check

- `seamless-auth-react` shows a generic message on any `/login` error and does not branch on the text ([Login.tsx:124](https://github.com/fells-code/seamless-auth-react)).
- Nothing in `seamless-auth-react`, `seamless-auth-server`, `seamless-cli`, `seamless-auth-types`, or the dashboard matches `"Need to verify"`, `"No available login methods"`, or `"Not Allowed"`.
- `loginMethods` is unchanged, so the React and CLI login flows are untouched.

No coordinated SDK change is required.

## #46 — `aud` claim (stale premise)

The issue says the server signs tokens with no `aud`. That is no longer true: `signAccessToken`, `signRefreshToken`, and `signEphemeralToken` all set `.setAudience(ISSUER)` as of `ff8067d`, and the adapter verifies `aud === audience`. I confirmed it on a running container: issued tokens carry `"aud": "http://localhost:5312"`.

Per your call, the scheme stays as-is and is now documented. A per-deployment audience is deliberate; a global `seamless-auth` literal would make every tenant share one audience string, so a token from one instance would satisfy an audience check on another. The internal service-token path keeps its own `aud: seamless-auth` because it is a different token family (M2M from `seamless-portal-api`), and neither verifier accepts the other's tokens.

## #59 — ephemeral token replay (accepted)

Documented as accepted with the mitigations named: the 5 minute TTL, per-IP and per-identity rate limiters on every continuation endpoint, and the fact that an ephemeral token authorizes a step that still requires the OTP code, magic-link token, or WebAuthn assertion. The doc also records what single-use would cost (server-side `jti` state, plus a failure mode where a dropped response strands a user mid-step) and names the conditions that should trigger a revisit.

## #109 — email and phone at rest (plaintext, documented)

Confirmed still true: `EMAIL_ENCRYPTION_KEY`, `PHONE_ENCRYPTION_KEY`, and `ENCRYPTION_IV` have zero references anywhere in the repo, and both columns are plaintext.

Documented as plaintext by design, with the reason: they are lookup keys, so encrypting them needs deterministic encryption or a blind index plus a backfill migration and a key-rotation story. Operators wanting encryption at rest are pointed at database-level encryption, which protects the same data without breaking lookups.

**Cross-repo follow-up, not done here:** `seamless-terraform-service` should stop injecting those three secrets into trial and paid stacks. They are misleading, implying an encryption that does not exist. Nothing in this repo reads them, so there is nothing to remove on this side.

## Docs

New `docs/security-posture.md`, linked from the README doc index and from `SECURITY.md` so these do not keep getting reported as vulnerabilities. Added to the `.gitignore` docs allowlist, without which a new `docs/*.md` is silently untracked in this repo.

## Checks

`npm run typecheck`, `npm run lint`, `npm run format:check`, and the suite pass (938 passed, 1 skipped). `openapi.json` and the generated types were regenerated. New test asserts the unknown, unverified, and no-method responses are byte-identical, and the two lookup-failure tests now assert matching status codes.