### PR TITLE
feat: standardize the error response shape

### DIFF
--- a/.changeset/great-mails-share.md
+++ b/.changeset/great-mails-share.md
@@ -1,0 +1,21 @@
+---
+'seamless-auth-api': minor
+---
+
+Standardize the error response shape. Every `4xx` and `5xx` response now carries a required
+`error` string, with `message` reserved for optional extra detail, so a consumer reads one field
+to learn why a call failed.
+
+25 handlers across the WebAuthn, user, internal metrics, dashboard, and security endpoints
+returned `{ message }` with no `error`. They now set `error`. Eight error responses on the
+`/internal/*` routes were declared with `MessageSchema`, which has no `error` field and would have
+stripped it; they now use `ErrorSchema`.
+
+`InternalErrorSchema` was a byte-identical duplicate of `ErrorSchema` and is now a deprecated alias
+of it. Nothing changes on the wire for the 53 routes that reference it.
+
+Success responses are untouched: `{ "message": "Success" }` on a `200` is a success payload, not an
+error body.
+
+A new conformance test walks every registered route and fails if a failure response declares a
+schema without a required `error` string, so a new route cannot reintroduce the split.

--- a/docs/api-contract.md
+++ b/docs/api-contract.md
@@ -61,8 +61,27 @@ protocol in [ecosystem.md](./ecosystem.md).
 
 ### Error body
 
-Error responses use `ErrorSchema`: `{ "error": string, "message"?: string }`. (Note: some
-handlers historically returned `{ message }` instead; standardizing this is tracked separately.)
+Every `4xx` and `5xx` response uses one shape:
+
+```json
+{ "error": "User already exists", "message": "optional extra detail" }
+```
+
+- **`error`** is always present and carries the human-readable reason. Read this field.
+- **`message`** is optional extra detail. It is never a substitute for `error`, so a consumer
+  never has to check two fields to find out why a call failed.
+
+Some handlers used to return `{ message }` with no `error`, which left the shape ambiguous. They
+now all set `error`. `tests/unit/routes/errorShapeCoverage.spec.ts` walks every registered route
+and fails if any failure response declares a schema without a required `error` string, so a new
+route cannot reintroduce the split.
+
+`ErrorSchema` in [`src/schemas/generic.responses.ts`](../src/schemas/generic.responses.ts) is the
+canonical definition. `InternalErrorSchema` is a deprecated alias of it and is identical on the
+wire.
+
+Success responses are unaffected: `{ "message": "Success" }` on a `200` is a success payload, not
+an error body, and clients that branch on it keep working.
 
 ## A note on login responses
 

--- a/src/controllers/internalDashboard.ts
+++ b/src/controllers/internalDashboard.ts
@@ -83,6 +83,6 @@ export const getDashboardMetrics = async (_req: Request, res: Response) => {
       databaseSize: dbSize,
     });
   } catch {
-    return res.status(500).json({ message: 'Failed to fetch dashboard metrics' });
+    return res.status(500).json({ error: 'Failed to fetch dashboard metrics' });
   }
 };

--- a/src/controllers/internalMetrics.ts
+++ b/src/controllers/internalMetrics.ts
@@ -127,7 +127,7 @@ export const getAuthEventSummary = async (req: Request, res: Response) => {
   const parsed = parseMetricsQuery(req);
 
   if (!parsed) {
-    return res.status(400).json({ message: 'Invalid query params' });
+    return res.status(400).json({ error: 'Invalid query params' });
   }
 
   const { query, from, to } = parsed;
@@ -136,7 +136,7 @@ export const getAuthEventSummary = async (req: Request, res: Response) => {
     return res.json({ summary: await countByType(scopeWhere(query, from, to)) });
   } catch (err) {
     logger.error(`Failed to fetch auth summary: ${err}`);
-    return res.status(500).json({ message: 'Failed to fetch summary' });
+    return res.status(500).json({ error: 'Failed to fetch summary' });
   }
 };
 
@@ -144,7 +144,7 @@ export const getAuthEventTimeseries = async (req: Request, res: Response) => {
   const parsed = parseMetricsQuery(req);
 
   if (!parsed) {
-    return res.status(400).json({ message: 'Invalid query params' });
+    return res.status(400).json({ error: 'Invalid query params' });
   }
 
   const { query, from, to } = parsed;
@@ -204,7 +204,7 @@ export const getAuthEventTimeseries = async (req: Request, res: Response) => {
     return res.json({ timeseries });
   } catch (err) {
     logger.error(`Failed to fetch timeseries: ${err}`);
-    return res.status(500).json({ message: 'Failed to fetch timeseries' });
+    return res.status(500).json({ error: 'Failed to fetch timeseries' });
   }
 };
 
@@ -212,7 +212,7 @@ export const getLoginStats = async (req: Request, res: Response) => {
   const parsed = parseMetricsQuery(req);
 
   if (!parsed) {
-    return res.status(400).json({ message: 'Invalid query params' });
+    return res.status(400).json({ error: 'Invalid query params' });
   }
 
   const { query, from, to } = parsed;
@@ -229,7 +229,7 @@ export const getLoginStats = async (req: Request, res: Response) => {
     });
   } catch (err) {
     logger.error(`Failed to compute login stats: ${err}`);
-    return res.status(500).json({ message: 'Failed to compute login stats' });
+    return res.status(500).json({ error: 'Failed to compute login stats' });
   }
 };
 
@@ -237,7 +237,7 @@ export const getGroupedEventSummary = async (req: Request, res: Response) => {
   const parsed = parseMetricsQuery(req);
 
   if (!parsed) {
-    return res.status(400).json({ message: 'Invalid query params' });
+    return res.status(400).json({ error: 'Invalid query params' });
   }
 
   const { query, from, to } = parsed;
@@ -262,6 +262,6 @@ export const getGroupedEventSummary = async (req: Request, res: Response) => {
     });
   } catch (err) {
     logger.error(`Failed to group auth events: ${err}`);
-    return res.status(500).json({ message: 'Failed to group events' });
+    return res.status(500).json({ error: 'Failed to group events' });
   }
 };

--- a/src/controllers/internalSecurity.ts
+++ b/src/controllers/internalSecurity.ts
@@ -60,6 +60,6 @@ export const getSecurityAnomalies = async (_req: Request, res: Response) => {
     });
   } catch {
     logger.error(`Failed to get security events`);
-    return res.status(500).json({ message: 'Failed to detect anomalies' });
+    return res.status(500).json({ error: 'Failed to detect anomalies' });
   }
 };

--- a/src/controllers/user.ts
+++ b/src/controllers/user.ts
@@ -60,7 +60,7 @@ export const getUser = async (req: Request, res: Response) => {
           organizations.find((organization) => organization.id === activeOrganizationId) ?? null,
       });
     } else {
-      return res.status(404).json({ message: 'User not found' });
+      return res.status(404).json({ error: 'User not found' });
     }
   } catch (error) {
     logger.error(`Error occured getting user: ${error}`);
@@ -70,7 +70,7 @@ export const getUser = async (req: Request, res: Response) => {
       req,
       metadata: { reason: 'Error occured' },
     });
-    res.status(500).json({ message: 'Internal server error' });
+    res.status(500).json({ error: 'Internal server error' });
     return;
   }
 };
@@ -80,7 +80,7 @@ export const deleteUser = async (req: Request, res: Response) => {
   const authUser = authReq.user;
 
   if (!authUser) {
-    return res.status(404).json({ message: 'User not found.' });
+    return res.status(404).json({ error: 'User not found.' });
   }
 
   logger.info('Authenticated user triggered account deletion');
@@ -126,7 +126,7 @@ export const deleteUser = async (req: Request, res: Response) => {
     return res.status(200).json({ message: 'Success' });
   } catch (error: unknown) {
     logger.error(`Failed to delete user: ${error}`);
-    return res.status(500).json({ message: 'Failed' });
+    return res.status(500).json({ error: 'Failed' });
   }
 };
 

--- a/src/controllers/webauthn.ts
+++ b/src/controllers/webauthn.ts
@@ -83,7 +83,7 @@ const registerWebAuthn = async (req: Request, res: Response) => {
         metadata: { reason: 'No verified user on the request.' },
       });
 
-      return res.status(403).json({ message: 'Not allowed' });
+      return res.status(403).json({ error: 'Not allowed' });
     }
 
     if (!verifiedUser.id || !verifiedUser.email) {
@@ -94,7 +94,7 @@ const registerWebAuthn = async (req: Request, res: Response) => {
         req,
         metadata: { reason: 'No verified user on the request.' },
       });
-      return res.status(403).json({ message: 'Not allowed' });
+      return res.status(403).json({ error: 'Not allowed' });
     }
 
     const existingCredentials = await Credential.findAll({
@@ -149,7 +149,7 @@ const registerWebAuthn = async (req: Request, res: Response) => {
       req,
       metadata: { reason: `Server error: ${err}` },
     });
-    res.status(500).json({ message: 'Internal Server Error' });
+    res.status(500).json({ error: 'Internal Server Error' });
   }
 };
 
@@ -169,7 +169,7 @@ const verifyWebAuthnRegistration = async (req: Request, res: Response) => {
         req,
         metadata: { reason: 'No verified user' },
       });
-      return res.status(403).json({ message: 'Not allowed' });
+      return res.status(403).json({ error: 'Not allowed' });
     }
 
     if (!verifiedUser.email || !attestationResponse) {
@@ -180,7 +180,7 @@ const verifyWebAuthnRegistration = async (req: Request, res: Response) => {
         req,
         metadata: { reason: 'No verified user' },
       });
-      return res.status(403).json({ message: 'Not allowed' });
+      return res.status(403).json({ error: 'Not allowed' });
     }
 
     const user = await User.findOne({
@@ -195,7 +195,7 @@ const verifyWebAuthnRegistration = async (req: Request, res: Response) => {
         req,
         metadata: { reason: 'Verified user with no user record' },
       });
-      return res.status(403).json({ message: 'Not allowed' });
+      return res.status(403).json({ error: 'Not allowed' });
     }
 
     const expectedChallenge = user.challenge;
@@ -207,7 +207,7 @@ const verifyWebAuthnRegistration = async (req: Request, res: Response) => {
         req,
         metadata: { reason: 'Missing challenge for registration' },
       });
-      return res.status(403).json({ message: 'Missing challenge' });
+      return res.status(403).json({ error: 'Missing challenge' });
     }
 
     let verification;
@@ -228,7 +228,7 @@ const verifyWebAuthnRegistration = async (req: Request, res: Response) => {
         req,
         metadata: { reason: 'Verification failed' },
       });
-      return res.status(500).json({ message: 'An error occured will verifying. Try again' });
+      return res.status(500).json({ error: 'An error occured will verifying. Try again' });
     }
 
     const { verified, registrationInfo } = verification;
@@ -241,7 +241,7 @@ const verifyWebAuthnRegistration = async (req: Request, res: Response) => {
         req,
         metadata: { reason: 'Verification failed' },
       });
-      return res.status(403).json({ message: 'Registration failed verification' });
+      return res.status(403).json({ error: 'Registration failed verification' });
     }
 
     const { credential, credentialBackedUp, credentialDeviceType } = registrationInfo;
@@ -333,7 +333,7 @@ const generateWebAuthn = async (req: Request, res: Response) => {
       req,
       metadata: { reason: 'No identifier' },
     });
-    return res.status(403).json({ message: 'Not allowed' });
+    return res.status(403).json({ error: 'Not allowed' });
   }
 
   creds = await Credential.findAll({ where: { userId: user.id } });
@@ -391,7 +391,7 @@ const generateWebAuthn = async (req: Request, res: Response) => {
       req,
       metadata: { reason: 'Catch all error' },
     });
-    return res.status(500).json({ message: 'Internal server error' });
+    return res.status(500).json({ error: 'Internal server error' });
   }
 };
 
@@ -430,7 +430,7 @@ const verifyWebAuthn = async (req: Request, res: Response) => {
         req,
         metadata: { reason: 'No identifier' },
       });
-      return res.status(403).json({ message: 'Not allowed' });
+      return res.status(403).json({ error: 'Not allowed' });
     }
 
     if (!user || !user.challenge) {

--- a/src/routes/internal.routes.ts
+++ b/src/routes/internal.routes.ts
@@ -14,7 +14,7 @@ import {
 import { getSecurityAnomalies } from '../controllers/internalSecurity.js';
 import { createRouter } from '../lib/createRouter.js';
 import { requireAdmin } from '../middleware/requireAdmin.js';
-import { MessageSchema } from '../schemas/generic.responses.js';
+import { ErrorSchema } from '../schemas/generic.responses.js';
 import { MetricsQuerySchema } from '../schemas/internal.query.js';
 import {
   AuthEventSummaryResponseSchema,
@@ -37,8 +37,8 @@ internalRouter.get(
       query: MetricsQuerySchema,
       response: {
         200: AuthEventSummaryResponseSchema,
-        400: MessageSchema,
-        500: MessageSchema,
+        400: ErrorSchema,
+        500: ErrorSchema,
       },
     },
   },
@@ -55,8 +55,8 @@ internalRouter.get(
       query: MetricsQuerySchema,
       response: {
         200: AuthEventTimeseriesResponseSchema,
-        400: MessageSchema,
-        500: MessageSchema,
+        400: ErrorSchema,
+        500: ErrorSchema,
       },
     },
   },
@@ -73,8 +73,8 @@ internalRouter.get(
       query: MetricsQuerySchema,
       response: {
         200: LoginStatsResponseSchema,
-        400: MessageSchema,
-        500: MessageSchema,
+        400: ErrorSchema,
+        500: ErrorSchema,
       },
     },
   },
@@ -91,7 +91,7 @@ internalRouter.get(
     schemas: {
       response: {
         200: SecurityAnomaliesResponseSchema,
-        500: MessageSchema,
+        500: ErrorSchema,
       },
     },
   },
@@ -108,7 +108,7 @@ internalRouter.get(
     schemas: {
       response: {
         200: DashboardMetricsResponseSchema,
-        500: MessageSchema,
+        500: ErrorSchema,
       },
     },
   },
@@ -126,8 +126,8 @@ internalRouter.get(
       query: MetricsQuerySchema,
       response: {
         200: GroupedAuthEventSummaryResponseSchema,
-        400: MessageSchema,
-        500: MessageSchema,
+        400: ErrorSchema,
+        500: ErrorSchema,
       },
     },
   },

--- a/src/schemas/generic.responses.ts
+++ b/src/schemas/generic.responses.ts
@@ -31,12 +31,17 @@ export const MessageSchema = z.object({
   delivery: AuthDeliverySchema.optional(),
 });
 
+/**
+ * The canonical error body. Every 4xx and 5xx response uses this shape, enforced by
+ * `tests/unit/routes/errorShapeCoverage.spec.ts`.
+ *
+ * `error` carries the human-readable reason and is always present. `message` is optional
+ * extra detail; it is not a substitute for `error`, so consumers can read one field.
+ */
 export const ErrorSchema = z.object({
   message: z.string().optional(),
   error: z.string(),
 });
 
-export const InternalErrorSchema = z.object({
-  message: z.string().optional(),
-  error: z.string(),
-});
+/** @deprecated Identical to {@link ErrorSchema}. Kept so route definitions need not churn. */
+export const InternalErrorSchema = ErrorSchema;

--- a/tests/integration/internal/internal.spec.ts
+++ b/tests/integration/internal/internal.spec.ts
@@ -198,7 +198,7 @@ describe('GET /internal/metrics/dashboard', () => {
     const res = await request(app).get('/internal/metrics/dashboard');
 
     expect(res.status).toBe(500);
-    expect(res.body.message).toBe('Failed to fetch dashboard metrics');
+    expect(res.body.error).toBe('Failed to fetch dashboard metrics');
   });
 });
 
@@ -271,7 +271,7 @@ describe('GET /internal/auth-events/grouped', () => {
     const res = await request(app).get('/internal/auth-events/grouped');
 
     expect(res.status).toBe(500);
-    expect(res.body.message).toBe('Failed to group events');
+    expect(res.body.error).toBe('Failed to group events');
   });
 });
 
@@ -293,7 +293,7 @@ describe('GET /internal/auth-events/summary (additional branches)', () => {
     const res = await request(app).get('/internal/auth-events/summary');
 
     expect(res.status).toBe(500);
-    expect(res.body.message).toBe('Failed to fetch summary');
+    expect(res.body.error).toBe('Failed to fetch summary');
   });
 });
 
@@ -364,7 +364,7 @@ describe('GET /internal/auth-events/timeseries (additional branches)', () => {
     const res = await request(app).get('/internal/auth-events/timeseries');
 
     expect(res.status).toBe(500);
-    expect(res.body.message).toBe('Failed to fetch timeseries');
+    expect(res.body.error).toBe('Failed to fetch timeseries');
   });
 });
 
@@ -375,7 +375,7 @@ describe('GET /internal/auth-events/login-stats (additional branches)', () => {
     const res = await request(app).get('/internal/auth-events/login-stats');
 
     expect(res.status).toBe(500);
-    expect(res.body.message).toBe('Failed to compute login stats');
+    expect(res.body.error).toBe('Failed to compute login stats');
   });
 
   it('reports a zero success rate when there are no logins', async () => {
@@ -395,7 +395,7 @@ describe('GET /internal/security/anomalies (additional branches)', () => {
     const res = await request(app).get('/internal/security/anomalies');
 
     expect(res.status).toBe(500);
-    expect(res.body.message).toBe('Failed to detect anomalies');
+    expect(res.body.error).toBe('Failed to detect anomalies');
   });
 });
 
@@ -413,7 +413,7 @@ describe('internal metrics query guards (direct invocation)', () => {
     await getAuthEventSummary({ query: { from: 'not-a-date' } } as any, res);
 
     expect(res.status).toHaveBeenCalledWith(400);
-    expect(res.json).toHaveBeenCalledWith({ message: 'Invalid query params' });
+    expect(res.json).toHaveBeenCalledWith({ error: 'Invalid query params' });
   });
 
   it('rejects an invalid timeseries query', async () => {
@@ -422,7 +422,7 @@ describe('internal metrics query guards (direct invocation)', () => {
     await getAuthEventTimeseries({ query: { interval: 'decade' } } as any, res);
 
     expect(res.status).toHaveBeenCalledWith(400);
-    expect(res.json).toHaveBeenCalledWith({ message: 'Invalid query params' });
+    expect(res.json).toHaveBeenCalledWith({ error: 'Invalid query params' });
   });
 });
 

--- a/tests/integration/user/user.spec.ts
+++ b/tests/integration/user/user.spec.ts
@@ -234,6 +234,6 @@ describe('user not-found branches', () => {
     const res = await request(app).delete('/users/delete').set('x-omit-user', 'true');
 
     expect(res.status).toBe(404);
-    expect(res.body.message).toBe('User not found.');
+    expect(res.body.error).toBe('User not found.');
   });
 });

--- a/tests/integration/webauthn/webauthn.spec.ts
+++ b/tests/integration/webauthn/webauthn.spec.ts
@@ -150,7 +150,7 @@ describe('GET /webauthn/register/start', () => {
     await registerWebAuthn(buildReq({ user: undefined }), res);
 
     expect(res.status).toHaveBeenCalledWith(403);
-    expect(res.json).toHaveBeenCalledWith({ message: 'Not allowed' });
+    expect(res.json).toHaveBeenCalledWith({ error: 'Not allowed' });
   });
 
   it('rejects when the verified user is missing an email', async () => {
@@ -159,7 +159,7 @@ describe('GET /webauthn/register/start', () => {
     await registerWebAuthn(buildReq({ user: { id: 'user-1', email: null } }), res);
 
     expect(res.status).toHaveBeenCalledWith(403);
-    expect(res.json).toHaveBeenCalledWith({ message: 'Not allowed' });
+    expect(res.json).toHaveBeenCalledWith({ error: 'Not allowed' });
   });
 });
 
@@ -327,7 +327,7 @@ describe('POST /webauthn/register/finish', () => {
     );
 
     expect(res.status).toHaveBeenCalledWith(403);
-    expect(res.json).toHaveBeenCalledWith({ message: 'Not allowed' });
+    expect(res.json).toHaveBeenCalledWith({ error: 'Not allowed' });
   });
 
   it('rejects when there is no verified user', async () => {
@@ -339,7 +339,7 @@ describe('POST /webauthn/register/finish', () => {
     );
 
     expect(res.status).toHaveBeenCalledWith(403);
-    expect(res.json).toHaveBeenCalledWith({ message: 'Not allowed' });
+    expect(res.json).toHaveBeenCalledWith({ error: 'Not allowed' });
   });
 
   it('completes registration and issues a session', async () => {
@@ -475,7 +475,7 @@ describe('POST /webauthn/login/start', () => {
     );
 
     expect(res.status).toHaveBeenCalledWith(403);
-    expect(res.json).toHaveBeenCalledWith({ message: 'Not allowed' });
+    expect(res.json).toHaveBeenCalledWith({ error: 'Not allowed' });
   });
 
   it('rejects when the user has no stored credentials', async () => {
@@ -617,7 +617,7 @@ describe('POST /webauthn/login/finish', () => {
     );
 
     expect(res.status).toHaveBeenCalledWith(403);
-    expect(res.json).toHaveBeenCalledWith({ message: 'Not allowed' });
+    expect(res.json).toHaveBeenCalledWith({ error: 'Not allowed' });
   });
 
   it('rejects when the user challenge is missing', async () => {

--- a/tests/unit/routes/errorShapeCoverage.spec.ts
+++ b/tests/unit/routes/errorShapeCoverage.spec.ts
@@ -1,0 +1,50 @@
+import express from 'express';
+import { ZodObject, ZodType } from 'zod';
+
+import { describe, expect, it } from 'vitest';
+
+import { loadRoutes } from '../../../src/lib/loadRoutes.js';
+import { registry } from '../../../src/openapi/registry.js';
+
+/**
+ * Every 4xx and 5xx response must carry a required `error` string, so a consumer can read
+ * one field to learn why a call failed. Handlers used to split between `{ error }` and
+ * `{ message }`, which left the shape ambiguous.
+ */
+describe('error response shape', () => {
+  it('declares a required error string on every failure response', async () => {
+    await loadRoutes(express());
+
+    const offenders: string[] = [];
+    let inspected = 0;
+
+    for (const definition of registry.definitions) {
+      if (definition.type !== 'route') continue;
+
+      const { method, path, responses } = definition.route;
+
+      for (const [status, response] of Object.entries(responses ?? {})) {
+        if (!/^[45]/.test(status)) continue;
+
+        const schema = (response as { content?: Record<string, { schema?: ZodType }> })?.content?.[
+          'application/json'
+        ]?.schema;
+
+        if (!schema) continue;
+
+        inspected += 1;
+
+        const shape = schema instanceof ZodObject ? schema.shape : undefined;
+        const errorField = shape?.error as ZodType | undefined;
+
+        if (!errorField || errorField.safeParse(undefined).success) {
+          offenders.push(`${method.toUpperCase()} ${path} -> ${status}`);
+        }
+      }
+    }
+
+    expect(offenders).toEqual([]);
+    // Guards against the assertion above passing because nothing was examined.
+    expect(inspected).toBeGreaterThan(100);
+  });
+});


### PR DESCRIPTION
Closes #61

## Contract change

Flagging per the ripple protocol. **The survey says no sibling repo needs a coordinated change** — details below.

## What was actually wrong

Partly stale. The issue says `ErrorSchema` "makes both optional"; it does not, `error` is already required and `message` optional, which is exactly the shape the issue recommends. The real inconsistency was narrower and I measured it:

- **153** error responses already returned `{ error }`.
- **25** returned `{ message }` with no `error`, in WebAuthn (12), internal metrics (6), user (4), dashboard, security, and one login branch.
- Of the 128 declared failure-response schemas, **65 used `ErrorSchema`, 53 used `InternalErrorSchema`** (a byte-identical duplicate), and only **8 used `MessageSchema`**, which has no `error` field.

So the codebase was already ~95% on `{ error }`. The split was a long tail, not an even divide.

## Change

- The 25 `{ message }` error responses now return `{ error }`, carrying the same prose. This matches the dominant existing convention, where `error` holds human-readable text like `"User already exists"`.
- The 8 `MessageSchema` failure responses (all on `/internal/*`) now use `ErrorSchema`. This mattered: response validation strips undeclared keys, so a handler setting `error` against `MessageSchema` would have had it silently removed before the client saw it.
- `InternalErrorSchema` becomes a deprecated alias of `ErrorSchema` rather than a second identical definition. The 53 routes referencing it are unchanged on the wire and did not need touching.
- **Success responses are untouched.** `{ "message": "Success" }` on a `200` is a success payload, not an error body. `seamless-auth-react` branches on `data.message === 'Success'` in `Login.tsx` and `MagicLinkSent.tsx`, and that keeps working.

## Conformance assertion

`tests/unit/routes/errorShapeCoverage.spec.ts` loads every route module, walks the OpenAPI registry, and fails if any `4xx`/`5xx` response declares a schema without a required `error` string. A new route cannot reintroduce the split.

I verified it is not vacuous two ways: it asserts it inspected more than 100 responses, and I temporarily reverted one route to `MessageSchema` and confirmed it failed with `GET /internal/auth-events/summary -> 500` before restoring it.

## Ripple survey

Every consumer already reads `error` first and falls back to `message`, so this change is a no-op for them, and they stop needing the fallback:

| Repo | Site | Behavior |
| --- | --- | --- |
| `seamless-auth-server` | `packages/core/src/upstreamError.ts:29` | `data.error`, else `data.message`, else fallback |
| `seamless-auth-react` | `src/client/errors.ts:66` | `error` if string, else `message` |
| `seamless-auth-admin-dashboard` | `src/lib/api.ts:100` | `fields.error ?? fields.message` |

`seamless-cli` surfaces its own `Error` objects rather than parsing upstream error bodies.

No `@seamless-auth/types` bump is needed: the canonical shape is unchanged, and only handlers that were not conforming to it moved.

## Note on merge order

The 8 route-schema changes are in `internal.routes.ts`, which PR #115 also touches. Whichever merges second will need a trivial conflict resolution. If #119 (typed client) is already merged, `npm run generate:api` should be rerun after this lands, since the `/internal/*` failure schemas change in the spec.

## Checks

`npm run typecheck`, `npm run lint`, `npm run format:check`, and `npm run coverage` pass (938 passed, 1 skipped). 15 test assertions that read `body.message` on error responses were updated to `body.error`.