### PR TITLE
fix: stop truncating passkey transports on the way out

### DIFF
--- a/.changeset/spotty-moons-repeat.md
+++ b/.changeset/spotty-moons-repeat.md
@@ -1,0 +1,17 @@
+---
+'seamless-auth-api': patch
+---
+
+Stop truncating passkey transports. A cross-device passkey reports `hybrid`, older Chrome reported
+`cable`, and security keys can report `smart-card`, but the credential serializer filtered
+`transports` down to the pre-hybrid `usb`/`ble`/`nfc`/`internal` set before building the response.
+Those credentials reported an empty transport list to every client, including `/users/me` and the
+admin user detail view.
+
+Stored data was never affected: the column is unconstrained JSON and registration writes the value
+through verbatim, so the correct transports come back as soon as the read path stops dropping them.
+No migration or backfill is needed.
+
+`CredentialResponseSchema` carries a local override widening `transports` to the full WebAuthn set,
+because `@seamless-auth/types@0.1.3` still declares the narrow one. The override and
+`src/lib/authenticatorTransports.ts` can both be deleted once the widened types release is adopted.

--- a/openapi.json
+++ b/openapi.json
@@ -1534,7 +1534,18 @@
                           "id": { "type": "string" },
                           "transports": {
                             "type": "array",
-                            "items": { "type": "string", "enum": ["usb", "ble", "nfc", "internal"] }
+                            "items": {
+                              "type": "string",
+                              "enum": [
+                                "ble",
+                                "cable",
+                                "hybrid",
+                                "internal",
+                                "nfc",
+                                "smart-card",
+                                "usb"
+                              ]
+                            }
                           },
                           "deviceType": {
                             "type": "string",
@@ -7186,7 +7197,18 @@
                           "id": { "type": "string" },
                           "transports": {
                             "type": "array",
-                            "items": { "type": "string", "enum": ["usb", "ble", "nfc", "internal"] }
+                            "items": {
+                              "type": "string",
+                              "enum": [
+                                "ble",
+                                "cable",
+                                "hybrid",
+                                "internal",
+                                "nfc",
+                                "smart-card",
+                                "usb"
+                              ]
+                            }
                           },
                           "deviceType": {
                             "type": "string",
@@ -7381,7 +7403,18 @@
                         "id": { "type": "string" },
                         "transports": {
                           "type": "array",
-                          "items": { "type": "string", "enum": ["usb", "ble", "nfc", "internal"] }
+                          "items": {
+                            "type": "string",
+                            "enum": [
+                              "ble",
+                              "cable",
+                              "hybrid",
+                              "internal",
+                              "nfc",
+                              "smart-card",
+                              "usb"
+                            ]
+                          }
                         },
                         "deviceType": { "type": "string", "enum": ["singleDevice", "multiDevice"] },
                         "backedUp": { "type": "boolean" },

--- a/resources/coverage-badge.svg
+++ b/resources/coverage-badge.svg
@@ -1,5 +1,5 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="111" height="20" role="img" aria-label="coverage: 99.4%">
-  <title>coverage: 99.4%</title>
+<svg xmlns="http://www.w3.org/2000/svg" width="97" height="20" role="img" aria-label="coverage: 99%">
+  <title>coverage: 99%</title>
   <linearGradient id="smooth" x2="0" y2="100%">
     <stop offset="0" stop-color="#fff" stop-opacity=".7"/>
     <stop offset=".1" stop-color="#aaa" stop-opacity=".1"/>
@@ -7,17 +7,17 @@
     <stop offset="1" stop-color="#000" stop-opacity=".5"/>
   </linearGradient>
   <clipPath id="round">
-    <rect width="111" height="20" rx="3" fill="#fff"/>
+    <rect width="97" height="20" rx="3" fill="#fff"/>
   </clipPath>
   <g clip-path="url(#round)">
     <rect width="66" height="20" fill="#555"/>
-    <rect x="66" width="45" height="20" fill="#2ea043"/>
-    <rect width="111" height="20" fill="url(#smooth)"/>
+    <rect x="66" width="31" height="20" fill="#2ea043"/>
+    <rect width="97" height="20" fill="url(#smooth)"/>
   </g>
   <g fill="#fff" text-anchor="middle" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" font-size="11">
     <text x="33" y="15" fill="#010101" fill-opacity=".3">coverage</text>
     <text x="33" y="14">coverage</text>
-    <text x="88.5" y="15" fill="#010101" fill-opacity=".3">99.4%</text>
-    <text x="88.5" y="14">99.4%</text>
+    <text x="81.5" y="15" fill="#010101" fill-opacity=".3">99%</text>
+    <text x="81.5" y="14">99%</text>
   </g>
 </svg>

--- a/src/generated/api.ts
+++ b/src/generated/api.ts
@@ -1437,7 +1437,15 @@ export interface paths {
               }[];
               credentials: {
                 id: string;
-                transports?: ('usb' | 'ble' | 'nfc' | 'internal')[];
+                transports?: (
+                  | 'ble'
+                  | 'cable'
+                  | 'hybrid'
+                  | 'internal'
+                  | 'nfc'
+                  | 'smart-card'
+                  | 'usb'
+                )[];
                 /** @enum {string} */
                 deviceType?: 'singleDevice' | 'multiDevice';
                 backedUp: boolean;
@@ -8068,7 +8076,15 @@ export interface paths {
               };
               credentials: {
                 id: string;
-                transports?: ('usb' | 'ble' | 'nfc' | 'internal')[];
+                transports?: (
+                  | 'ble'
+                  | 'cable'
+                  | 'hybrid'
+                  | 'internal'
+                  | 'nfc'
+                  | 'smart-card'
+                  | 'usb'
+                )[];
                 /** @enum {string} */
                 deviceType?: 'singleDevice' | 'multiDevice';
                 backedUp: boolean;
@@ -8212,7 +8228,15 @@ export interface paths {
               message: string;
               credential: {
                 id: string;
-                transports?: ('usb' | 'ble' | 'nfc' | 'internal')[];
+                transports?: (
+                  | 'ble'
+                  | 'cable'
+                  | 'hybrid'
+                  | 'internal'
+                  | 'nfc'
+                  | 'smart-card'
+                  | 'usb'
+                )[];
                 /** @enum {string} */
                 deviceType?: 'singleDevice' | 'multiDevice';
                 backedUp: boolean;

--- a/src/lib/authenticatorTransports.ts
+++ b/src/lib/authenticatorTransports.ts
@@ -1,0 +1,31 @@
+/*
+ * Copyright © 2026 Fells Code, LLC
+ * Licensed under the GNU Affero General Public License v3.0
+ * See LICENSE file in the project root for full license information
+ */
+
+/**
+ * The full WebAuthn transport set, matching SimpleWebAuthn's
+ * `AuthenticatorTransportFuture`, which is what registration actually stores.
+ *
+ * The older four-value set (usb, ble, nfc, internal) predates hybrid transport. A
+ * cross-device passkey, a phone authenticating a desktop browser, reports `hybrid`,
+ * older Chrome reported `cable`, and security keys can report `smart-card`. Narrowing
+ * to the old four silently emptied `transports` for those credentials on the way out,
+ * even though the stored value was correct.
+ *
+ * `@seamless-auth/types` widens `CredentialApiSchema.transports` to this same set in
+ * its next release. Once this repo picks that up, this module and the local schema
+ * override in `credential.responses.ts` can both go away.
+ */
+export const AUTHENTICATOR_TRANSPORTS = [
+  'ble',
+  'cable',
+  'hybrid',
+  'internal',
+  'nfc',
+  'smart-card',
+  'usb',
+] as const;
+
+export type AuthenticatorTransport = (typeof AUTHENTICATOR_TRANSPORTS)[number];

--- a/src/schemas/credential.responses.ts
+++ b/src/schemas/credential.responses.ts
@@ -7,10 +7,15 @@
 import { CredentialApiSchema } from '@seamless-auth/types';
 import { z } from 'zod';
 
+import { AUTHENTICATOR_TRANSPORTS } from '../lib/authenticatorTransports.js';
+
 export const CredentialResponseSchema = CredentialApiSchema.extend({
   backedup: z.boolean(),
   backedUp: z.boolean(),
   prfCapable: z.boolean().optional(),
+  // `CredentialApiSchema` in @seamless-auth/types@0.1.3 still declares the pre-hybrid
+  // four-value transport set. Drop this override once the widened release is adopted.
+  transports: z.array(z.enum(AUTHENTICATOR_TRANSPORTS)).optional(),
 });
 
 export const CredentialUpdateResponseSchema = z.object({

--- a/src/services/apiResponseSerializers.ts
+++ b/src/services/apiResponseSerializers.ts
@@ -4,6 +4,11 @@
  * See LICENSE file in the project root for full license information
  */
 
+import {
+  AUTHENTICATOR_TRANSPORTS,
+  AuthenticatorTransport,
+} from '../lib/authenticatorTransports.js';
+
 type SerializableRecord = Record<string, unknown>;
 
 function isRecord(value: unknown): value is SerializableRecord {
@@ -91,15 +96,12 @@ function credentialDeviceTypeField(
   return value === 'singleDevice' || value === 'multiDevice' ? value : undefined;
 }
 
-function transportField(
-  credential: unknown,
-): Array<'usb' | 'ble' | 'nfc' | 'internal'> | undefined {
+function transportField(credential: unknown): AuthenticatorTransport[] | undefined {
   const transports = optionalStringArrayField(credential, 'transports');
   if (transports === undefined) return undefined;
 
-  return transports.filter(
-    (transport): transport is 'usb' | 'ble' | 'nfc' | 'internal' =>
-      transport === 'usb' || transport === 'ble' || transport === 'nfc' || transport === 'internal',
+  return transports.filter((transport): transport is AuthenticatorTransport =>
+    (AUTHENTICATOR_TRANSPORTS as readonly string[]).includes(transport),
   );
 }
 

--- a/tests/unit/schemas/credentialResponses.spec.ts
+++ b/tests/unit/schemas/credentialResponses.spec.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+
+import { CredentialResponseSchema } from '../../../src/schemas/credential.responses.js';
+import { serializeCredential } from '../../../src/services/apiResponseSerializers.js';
+
+describe('CredentialResponseSchema', () => {
+  it('accepts a serialized cross-device passkey end to end', () => {
+    const serialized = serializeCredential({
+      id: 'credential-hybrid',
+      userId: 'user-1',
+      publicKey: 'public-key',
+      counter: 0,
+      transports: ['hybrid'],
+      deviceType: 'multiDevice',
+      backedUp: true,
+      createdAt: new Date('2026-01-01T00:00:00.000Z'),
+    });
+
+    const parsed = CredentialResponseSchema.safeParse(serialized);
+
+    // The serializer used to drop `hybrid`, and the schema used to reject it, so a
+    // cross-device passkey reported an empty transport list to every client.
+    expect(parsed.success).toBe(true);
+    expect(parsed.success && parsed.data.transports).toEqual(['hybrid']);
+  });
+
+  it('still rejects a transport that is not in the WebAuthn set', () => {
+    const parsed = CredentialResponseSchema.safeParse({
+      id: 'credential-1',
+      userId: 'user-1',
+      publicKey: 'public-key',
+      counter: 0,
+      transports: ['bogus'],
+      backedUp: false,
+      backedup: false,
+      createdAt: '2026-01-01T00:00:00.000Z',
+    });
+
+    expect(parsed.success).toBe(false);
+  });
+});

--- a/tests/unit/services/apiResponseSerializers.spec.ts
+++ b/tests/unit/services/apiResponseSerializers.spec.ts
@@ -163,6 +163,16 @@ describe('api response serializers', () => {
     expect(invalidType).not.toHaveProperty('createdAt');
   });
 
+  it('preserves hybrid and other post-2019 transports', () => {
+    const credential = serializeCredential({
+      id: 'credential-hybrid',
+      // A cross-device passkey (phone authenticating a desktop browser).
+      transports: ['hybrid', 'cable', 'smart-card'],
+    });
+
+    expect(credential.transports).toEqual(['hybrid', 'cable', 'smart-card']);
+  });
+
   it('filters webauthn transports and device type to known values', () => {
     const credential = serializeCredential({
       id: 'credential-2',


### PR DESCRIPTION
Closes #123

## What the investigation found

The issue asked three questions. Answers, in order:

**3. Did registration ever persist the wider values?** Yes. `transports` is a `DataTypes.JSON` column with no constraint, typed `AuthenticatorTransportFuture[]`, and `Credential.create` writes SimpleWebAuthn's `registrationInfo.credential.transports` straight through (`src/controllers/webauthn.ts:271`). Nothing filters on the way in.

**2. What does the route layer do on a response schema mismatch?** It logs the `ZodError` and sends the original unparsed payload, so a mismatch would have been noisy but not lossy. **That path was never reached here**, which is the important part.

**1. Was data lost?** Not at rest, only on the way out, and not where the issue expected. `transportField` in `src/services/apiResponseSerializers.ts` hard-filtered to the four legacy values *before* the response object was built. So the response always matched its schema, nothing threw, nothing was logged, and the client silently received `transports: []` for any cross-device passkey.

The practical consequence: **picking up the widened `@seamless-auth/types` release would not have fixed this on its own.** The serializer would have kept dropping the values regardless of what the schema allowed. That is worth noting on fells-code/seamless-auth-types#4 and on #124.

Because the stored data is intact, no migration or backfill is needed. Correct transports come back the moment the read path stops discarding them.

## Change

- `src/lib/authenticatorTransports.ts` declares the full WebAuthn set (`ble`, `cable`, `hybrid`, `internal`, `nfc`, `smart-card`, `usb`), matching SimpleWebAuthn's `AuthenticatorTransportFuture`, which is the type the column already holds.
- `transportField` filters against that set instead of the hardcoded four. Genuinely unknown values are still dropped, so a malformed row cannot break a response.
- `CredentialResponseSchema` overrides `transports` with the wide set, because `@seamless-auth/types@0.1.3` (the latest published) still declares the narrow one. Without the override the widened serializer output would fail response validation on every hybrid credential.

Both the override and the new module are marked for deletion once the widened types release is adopted, so this does not add permanent duplication.

## Tests

- The serializer preserves `hybrid`, `cable`, and `smart-card`.
- The existing test asserting unknown values are dropped still passes unchanged.
- An end-to-end check feeds `serializeCredential` output through `CredentialResponseSchema`, which is what actually proves a cross-device passkey survives the full read path rather than just one half of it.

## Still outstanding

The issue's first question also asked whether any *stored* credential has a wider transport. That needs a query against real tenant databases, which I cannot reach. Since the write path preserves the values, any cross-device passkey ever registered will have them. To confirm volume:

```sql
SELECT jsonb_array_elements_text(transports::jsonb) AS transport, count(*)
FROM credentials
WHERE transports IS NOT NULL
GROUP BY 1 ORDER BY 2 DESC;
```

Whatever it returns, no remediation follows from it: those rows start reporting correctly once this ships.

## Checks

`npm run typecheck`, `npm run lint`, `npm run format:check`, and the suite pass (985 passed, 1 skipped). `openapi.json` and the generated types were regenerated, and the widened enum shows up in the committed spec.