### PR TITLE
chore: mark bootstrap invite removal changeset as minor

### DIFF
--- a/.changeset/tidy-badgers-invite.md
+++ b/.changeset/tidy-badgers-invite.md
@@ -1,5 +1,5 @@
 ---
-'seamless-auth-api': major
+'seamless-auth-api': minor
 ---
 
 Remove the admin bootstrap invite flow. `POST /internal/bootstrap/admin-invite` is gone, along with


### PR DESCRIPTION
## Summary

The changeset for the admin bootstrap invite removal (`.changeset/tidy-badgers-invite.md`) was marked `major`. This repo is still pre v1, so breaking contract changes ship as minor bumps. Changed `major` to `minor`.

No code changes, only changeset metadata.

## Note on release notes

The described change is genuinely breaking even though the version bump is minor:

- `POST /internal/bootstrap/admin-invite` removed
- `bootstrapToken` removed from `POST /registration/register`
- `bootstrap_invite_email` external delivery kind removed
- `bootstrap_admin_granted` / `bootstrap_admin_check_skipped` auth event types removed
- `SEAMLESS_BOOTSTRAP_ENABLED`, `SEAMLESS_BOOTSTRAP_SECRET`, `SEAMLESS_AUTH_DEBUG_SECRETS` removed
- migration drops the `bootstrap_invites` table

Dependents that still call the invite endpoint or send `bootstrapToken` will break on this release, so the changeset body carrying that detail matters more than the bump level does.

## Checks

- `npm run format:check` passes
- `npm run typecheck` passes
- `npm run lint` passes
- pre-commit hook ran coverage and build, both passed