### PR TITLE
fix: correct OTP verification error messages

### DIFF
--- a/src/lib/token.ts
+++ b/src/lib/token.ts
@@ -98,7 +98,7 @@ export async function signEphemeralToken(userId: string) {
     return jwt;
   } catch (error) {
     logger.error(`Failed to create JWT token. Ephemeral. Reason: ${error}.`);
-    throw new Error('Failed to sign Ephemeral Token');
+    throw new Error('Failed to sign Ephemeral Token', { cause: error });
   }
 }
 

--- a/src/utils/otp.ts
+++ b/src/utils/otp.ts
@@ -93,7 +93,7 @@ export const generateEmailOTP = async (
     return emailToken;
   } catch (error) {
     logger.error(`Error generate email OTP: ${error}`);
-    throw new Error('Failed to set user OTP');
+    throw new Error('Failed to set user OTP', { cause: error });
   }
 };
 
@@ -129,7 +129,7 @@ export const generatePhoneOTP = async (
     return phoneToken;
   } catch (error) {
     logger.error(`Error generate phone OTP: ${error}`);
-    throw new Error('Failed to set user OTP');
+    throw new Error('Failed to set user OTP', { cause: error });
   }
 };
 
@@ -157,7 +157,7 @@ export const verifyPhoneOTP = async (
       await user.save();
     } catch (error) {
       logger.error(`Error verifying phone OTP: ${error}`);
-      throw new Error('Failed to update user verfication via phone OTP');
+      throw new Error('Failed to update user verfication via phone OTP', { cause: error });
     }
   } else {
     return { user, verified: false };
@@ -190,7 +190,7 @@ export const verifyEmailOTP = async (
       await user.save();
     } catch (error) {
       logger.error(`Error verifying email OTP: ${error}`);
-      throw new Error('Failed to update user verfication via phone OTP');
+      throw new Error('Failed to update user verfication via phone OTP', { cause: error });
     }
   } else {
     return { user, verified: false };

--- a/src/utils/otp.ts
+++ b/src/utils/otp.ts
@@ -157,7 +157,7 @@ export const verifyPhoneOTP = async (
       await user.save();
     } catch (error) {
       logger.error(`Error verifying phone OTP: ${error}`);
-      throw new Error('Failed to update user verfication via phone OTP', { cause: error });
+      throw new Error('Failed to update user verification via phone OTP', { cause: error });
     }
   } else {
     return { user, verified: false };
@@ -171,7 +171,7 @@ export const verifyEmailOTP = async (
   verificationToken: string,
 ): Promise<{ user: User; verified: boolean }> => {
   if (!user || !user.emailVerificationToken || !user.emailVerificationTokenExpiry) {
-    throw new Error('Cannot verify phone OTP due to incomplete user data');
+    throw new Error('Cannot verify email OTP due to incomplete user data');
   }
 
   if (
@@ -190,7 +190,7 @@ export const verifyEmailOTP = async (
       await user.save();
     } catch (error) {
       logger.error(`Error verifying email OTP: ${error}`);
-      throw new Error('Failed to update user verfication via phone OTP', { cause: error });
+      throw new Error('Failed to update user verification via email OTP', { cause: error });
     }
   } else {
     return { user, verified: false };

--- a/tests/unit/utils/otp.spec.ts
+++ b/tests/unit/utils/otp.spec.ts
@@ -308,7 +308,7 @@ describe('OTP verification save failures', () => {
     });
 
     await expect(verifyPhoneOTP(user as any, '123456')).rejects.toThrow(
-      'Failed to update user verfication via phone OTP',
+      'Failed to update user verification via phone OTP',
     );
     expect(user.save).toHaveBeenCalled();
   });
@@ -322,7 +322,7 @@ describe('OTP verification save failures', () => {
     });
 
     await expect(verifyEmailOTP(user as any, 'abcdef')).rejects.toThrow(
-      'Failed to update user verfication via phone OTP',
+      'Failed to update user verification via email OTP',
     );
     expect(user.save).toHaveBeenCalled();
   });


### PR DESCRIPTION
## Summary

Fixes three error-message defects in `src/utils/otp.ts`, plus the bare rethrows that were failing lint.

`verifyEmailOTP` reported "phone OTP" in two places, a copy-paste carryover from `verifyPhoneOTP`, and "verfication" was misspelled in both save-failure messages.

| Location | Before | After |
| --- | --- | --- |
| `verifyPhoneOTP` save failure | `Failed to update user verfication via phone OTP` | `Failed to update user verification via phone OTP` |
| `verifyEmailOTP` guard | `Cannot verify phone OTP due to incomplete user data` | `Cannot verify email OTP due to incomplete user data` |
| `verifyEmailOTP` save failure | `Failed to update user verfication via phone OTP` | `Failed to update user verification via email OTP` |

## Not a contract change

These strings only reach the server logs. The top-level handler in `src/app.ts` returns a fixed `{ error: 'Internal server error' }` body, so no response payload changes and no dependent repo is affected. No changeset for that reason.

## Why the cause commit is included

The `preserve-caught-error` lint rule was already failing on five bare rethrows at `main`, which blocked the pre-commit hook entirely. The first commit attaches the caught error as `cause` on all five, so lint passes and each commit is independently green. That also stops discarding the original stack in the logs.

Commits are split so the mechanical `cause` change is reviewable separately from the message fixes.

## Verification

- `npm run lint` clean (was 5 errors at `main`)
- `npm run typecheck` clean
- `npm run test:run` 91 files, 960 passed, 1 skipped
- `npm run build` succeeds

Two existing assertions in `tests/unit/utils/otp.spec.ts` referenced the old strings and were updated to match.