### PR TITLE
fix(registration): send the response ttl as a number

### DIFF
--- a/.changeset/registration-ttl-is-a-number.md
+++ b/.changeset/registration-ttl-is-a-number.md
@@ -1,0 +1,14 @@
+---
+'seamless-auth-api': patch
+---
+
+Send the registration response's `ttl` as a number.
+
+It was the string `'300'`, the only `ttl` this API sends that was not a number. A caller sets its
+registration cookie from it, and the Fastify adapter passes the value to a cookie library that
+requires an integer, so registration failed there with `TypeError: option maxAge is invalid: 300`.
+The Express adapter multiplies it into milliseconds, which coerces the string, so the same response
+worked and the mismatch went unnoticed.
+
+Requires `@seamless-auth/types` 0.6.0, where `RegistrationSuccessSchema.ttl` becomes a number.
+Response bodies are validated against that schema at runtime, so the two move together.

--- a/openapi.json
+++ b/openapi.json
@@ -1,6 +1,6 @@
 {
   "openapi": "3.0.3",
-  "info": { "title": "Seamless Auth API", "version": "0.6.0" },
+  "info": { "title": "Seamless Auth API", "version": "0.7.0" },
   "components": {
     "schemas": {},
     "parameters": {},
@@ -5415,7 +5415,7 @@
                     "message": { "type": "string" },
                     "sub": { "type": "string" },
                     "token": { "type": "string" },
-                    "ttl": { "type": "string" },
+                    "ttl": { "type": "number" },
                     "delivery": {
                       "oneOf": [
                         {
@@ -5455,7 +5455,7 @@
                   "message": "string",
                   "sub": "string",
                   "token": "string",
-                  "ttl": "string",
+                  "ttl": 0,
                   "delivery": null
                 }
               }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,19 +1,19 @@
 {
   "name": "seamless-auth-api",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "seamless-auth-api",
-      "version": "0.6.0",
+      "version": "0.7.0",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@asteasolutions/zod-to-openapi": "^8.4.3",
         "@seamless-auth/messaging": "^0.1.0",
         "@seamless-auth/messaging-aws": "^0.1.0",
         "@seamless-auth/messaging-twilio": "^0.1.0",
-        "@seamless-auth/types": "^0.5.0",
+        "@seamless-auth/types": "^0.6.0",
         "@simplewebauthn/server": "^13.1.1",
         "base64url": "^3.0.1",
         "bcrypt-ts": "^7.1.0",
@@ -3393,9 +3393,9 @@
       }
     },
     "node_modules/@seamless-auth/types": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@seamless-auth/types/-/types-0.5.0.tgz",
-      "integrity": "sha512-T566YQu8FqUmqgte0A0iJpjTDXUKq/d/7uvLlXGXKtdl52Edo0r3iafL3kx4OM0cRJM63tBGe9s4MTjRUth6yA==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@seamless-auth/types/-/types-0.6.0.tgz",
+      "integrity": "sha512-jsgSn6gAKFXpdKdQ0B4GconuKNWTQihCZLqqHmKYztolN4c3zMnrWrK3nQHup2a7q/TLxlk25HDZw2j4WxkjOA==",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "zod": "^4.3.6"

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "@seamless-auth/messaging": "^0.1.0",
     "@seamless-auth/messaging-aws": "^0.1.0",
     "@seamless-auth/messaging-twilio": "^0.1.0",
-    "@seamless-auth/types": "^0.5.0",
+    "@seamless-auth/types": "^0.6.0",
     "@simplewebauthn/server": "^13.1.1",
     "base64url": "^3.0.1",
     "bcrypt-ts": "^7.1.0",

--- a/src/controllers/registration.ts
+++ b/src/controllers/registration.ts
@@ -158,7 +158,10 @@ export const register = async (req: Request, res: Response) => {
       message: 'Success',
       sub: user.id,
       token,
-      ttl: '300',
+      // Seconds, and it has to match the `5m` in signEphemeralToken. A caller
+      // sets its registration cookie from this, so a larger value here leaves a
+      // cookie outliving the token it carries.
+      ttl: 300,
       ...(delivery ? { delivery } : {}),
     });
   } catch (error: unknown) {

--- a/src/generated/api.ts
+++ b/src/generated/api.ts
@@ -5769,7 +5769,7 @@ export interface paths {
              *       "message": "string",
              *       "sub": "string",
              *       "token": "string",
-             *       "ttl": "string",
+             *       "ttl": 0,
              *       "delivery": null
              *     }
              */
@@ -5777,7 +5777,7 @@ export interface paths {
               message: string;
               sub?: string;
               token?: string;
-              ttl?: string;
+              ttl?: number;
               delivery?:
                 | {
                     /** @enum {string} */


### PR DESCRIPTION
Second of three. **Draft: blocked on fells-code/seamless-auth-types#27.**

Response bodies are validated against `RegistrationSuccessSchema` at runtime, so with the published `types@0.5.0` (which still declares `ttl: z.string()`) this change makes registration return **500**. The test suite catches that, which is how I confirmed the coupling. Verified against a local build of the fixed types package. The dependency bump is the last commit here before it comes out of draft.

## The bug

Registration fails on the Fastify adapter with `TypeError: option maxAge is invalid: 300`, because this API sends `ttl: '300'` as a string and `cookie` requires `Number.isInteger`.

It was the only `ttl` this API sends that was not a number. The Express adapter multiplies it into milliseconds, which coerces the string, so the same response has always worked there and the mismatch went unnoticed.

## The change

`ttl: '300'` becomes `ttl: 300`, with a comment recording the invariant that it has to match the `5m` in `signEphemeralToken`. A caller sets its registration cookie from this value, so a larger number here would leave a cookie outliving the token it carries.

`openapi.json` and `src/generated/api.ts` regenerated: `"ttl": { "type": "string" }` becomes `"type": "number"`. The contract test enforces it.

## Scope I backed out

I first hoisted the lifetime into an exported `EPHEMERAL_TOKEN_TTL_SECONDS` so the `5m` and the `300` collapsed into one value. Four test files mock `src/lib/token.js`, and each would have needed the new export added to its mock. That is a lot of test-infrastructure churn for what is a one-word type fix, so I reverted it and left the invariant as a comment.

Worth doing on its own: the two literals can still drift, and a comment is weaker than a shared constant. Happy to open it separately.

## Verification

`npm run typecheck`, `npm run test:run` (91 files, all passing), `npm run lint`, `npm run format:check` all clean, against a local build of the types fix.