### PR TITLE
fix(dev): keep container dependencies in sync with package-lock

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,6 +47,19 @@ the database on first boot), and starts a watcher that reloads on change. No `.e
 needed: the compose file supplies development defaults. If you do create one, its values win, so
 you can point at a real messaging transport or OAuth provider without editing the compose file.
 
+The container installs its own `node_modules` into a volume rather than using the one on your
+machine, which is built for your platform rather than the container's. Every boot checks that
+volume against `package-lock.json` and reinstalls when the two have diverged, so pulling a branch
+that adds or bumps a dependency needs nothing beyond a restart. To throw the volume away and
+start from a clean install:
+
+```bash
+docker compose -f docker-compose.dev.yml down
+docker volume rm seamless-auth-dev_node-modules-dev
+```
+
+`docker compose -f docker-compose.dev.yml down -v` removes it too, along with the database.
+
 To run the project rather than work on it, use `docker compose up` instead. That uses the
 published image and also serves the admin console at `/console`, which the dev stack does not
 bundle. See the Docker Quickstart in [README.md](./README.md).

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -4,8 +4,8 @@ WORKDIR /app
 
 RUN apk add --no-cache postgresql-client netcat-openbsd
 
-COPY package.json package-lock.json* ./
-RUN npm ci
+COPY package.json package-lock.json* syncDevDeps.sh ./
+RUN sh ./syncDevDeps.sh
 
 COPY . .
 RUN mkdir -p ./keys

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -19,13 +19,18 @@ services:
       - '${API_PORT:-5312}:5312'
     volumes:
       - .:/app
-      - /app/node_modules
+      # node_modules stays out of the bind mount: the host tree is built for the host's
+      # platform. syncDevDeps.sh reinstalls into this volume whenever package-lock.json
+      # has moved on, since the volume itself outlives `up --build`.
+      - node-modules-dev:/app/node_modules
     # Dockerfile.dev has no build step, so the compiled entrypoint cannot run from a
-    # fresh clone. Generate dev signing keys, migrate (creating the database on first
-    # boot), then run the watcher against the TypeScript sources.
+    # fresh clone. Install any dependencies added since this container last booted,
+    # generate dev signing keys, migrate (creating the database on first boot), then
+    # run the watcher against the TypeScript sources.
     entrypoint: ['/bin/sh', '-c']
     command:
       - >
+        ./syncDevDeps.sh &&
         npx tsx src/scripts/initKeys.ts &&
         (npm run migrate:up || (npm run db:create && npm run migrate:up)) &&
         npm run dev:container
@@ -88,3 +93,4 @@ services:
 
 volumes:
   pgdata-dev:
+  node-modules-dev:

--- a/syncDevDeps.sh
+++ b/syncDevDeps.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+# Installs node_modules when it does not match package-lock.json.
+#
+# The dev stack keeps node_modules in its own volume so the host tree, built for the
+# host's platform, never reaches the container. That volume outlives `docker compose
+# up --build`, so without this the container keeps running whatever was installed the
+# first time it booted, however far package.json has moved on since.
+#
+# Also run at image build time, so a fresh volume inherits a stamp that matches what
+# the image already installed and the first boot does not reinstall it.
+set -eu
+
+STAMP=node_modules/.package-lock-stamp
+LOCK_HASH="$(md5sum package-lock.json | cut -d ' ' -f 1)"
+
+if [ -f "$STAMP" ] && [ "$(cat "$STAMP")" = "$LOCK_HASH" ]; then
+  echo "Dependencies match package-lock.json, skipping install."
+  exit 0
+fi
+
+echo "Installing dependencies from package-lock.json..."
+npm ci --no-audit --no-fund
+printf '%s' "$LOCK_HASH" > "$STAMP"


### PR DESCRIPTION
## Problem

`docker-compose.dev.yml` masked `node_modules` with an anonymous volume (`- /app/node_modules`).
That volume persists across `docker compose up --build`, so the container kept running whatever
was installed the first time it booted, however far the host's `package.json` had moved on.

It surfaced on 2026-07-31 as a boot crash:

```
The requested module '@seamless-auth/types' does not provide an export named 'PublicSystemConfigResponseSchema'
```

The host had `@seamless-auth/types` 0.6.0, which exports it. The container had 0.4.0, which does
not. The error reads like a bug in `@seamless-auth/types` rather than a stale install, so it costs
real debugging time, and it only cleared with `--renew-anon-volumes`.

## Change

- `syncDevDeps.sh` hashes `package-lock.json`, compares it to a stamp stored inside the volume, and
  runs `npm ci` only when the two have diverged.
- `Dockerfile.dev` runs the same script instead of a bare `npm ci`, so the stamp ships in the image
  and a fresh volume does not reinstall what the image already has.
- The volume is now named (`node-modules-dev`) rather than anonymous, so it can be listed and
  dropped by name.
- `CONTRIBUTING.md` documents that the container owns its own `node_modules`, that it re-syncs on
  boot, and how to discard the volume.

`node_modules` stays out of the bind mount on purpose. The host tree is built for the host's
platform, so sharing it breaks platform-specific binaries (esbuild under `tsx`, `sqlite3`).

## Verification

Run against an isolated stack (`-p sa-dev-verify`, ports 5399/55432), then torn down with its
volumes.

1. First boot on a fresh volume: `Dependencies match package-lock.json, skipping install.` Healthy,
   types 0.6.0, no redundant install.
2. Pinned the lockfile to types 0.5.0 and restarted: reinstalled, and the volume then held 0.5.0.
   The container tracks the lockfile rather than the image.
3. Restored 0.6.0 and ran a plain `docker compose up -d` against the now stale volume, reproducing
   the original failure: it reinstalled (`added 845 packages in 5s`) and came up healthy on 0.6.0.
   No `--renew-anon-volumes` needed.
4. Restart with an unchanged lockfile: install skipped, so boots stay fast.

Checks: `format:check` clean, `lint` clean, `typecheck` clean, `test:run` 91 files, 963 passed,
1 skipped.

No changeset: this is contributor tooling and does not change the published package's behavior.

## Note for existing dev stacks

An existing `seamless-auth-dev` stack still holds the old anonymous volume. After
`docker compose -f docker-compose.dev.yml down` and `up -d --build`, it switches to the named
volume, and the orphaned anonymous volume can be cleared with `docker volume prune`.