### PR TITLE
fix(config): drop the orphaned bootstrap secret check from validateEnvs

### DIFF
--- a/.changeset/drop-orphaned-bootstrap-env-check.md
+++ b/.changeset/drop-orphaned-bootstrap-env-check.md
@@ -1,0 +1,10 @@
+---
+'seamless-auth-api': patch
+---
+
+Drop the orphaned bootstrap secret check from the container entrypoint.
+
+`validateEnvs.sh` still required `SEAMLESS_BOOTSTRAP_SECRET` whenever `SEAMLESS_BOOTSTRAP_ENABLED`
+was `true`. Both variables were removed with the admin bootstrap invite flow, so nothing in the
+runtime reads either one. A deployment that carried the old `SEAMLESS_BOOTSTRAP_ENABLED=true` over
+from a previous release refused to boot until it supplied a secret that no longer did anything.

--- a/validateEnvs.sh
+++ b/validateEnvs.sh
@@ -50,10 +50,6 @@ fi
 
 require_var API_SERVICE_TOKEN
 
-if [ "${SEAMLESS_BOOTSTRAP_ENABLED:-false}" = "true" ]; then
-  require_var SEAMLESS_BOOTSTRAP_SECRET
-fi
-
 if [ "${NODE_ENV:-development}" = "production" ]; then
   require_var SEAMLESS_JWKS_ACTIVE_KID
   require_var JWKS_PUBLIC_KEYS


### PR DESCRIPTION
## What changed

Removes this block from [validateEnvs.sh](validateEnvs.sh):

```sh
if [ "${SEAMLESS_BOOTSTRAP_ENABLED:-false}" = "true" ]; then
  require_var SEAMLESS_BOOTSTRAP_SECRET
fi
```

## Why

Both variables were removed along with the admin bootstrap invite flow in `e9c10b1` (`refactor!: remove the admin bootstrap invite flow`). That commit touched `.env.example`, `README.md`, `docs/configuration.md`, and `docs/ecosystem.md`, but not `validateEnvs.sh`, so the guard was left behind.

Nothing in the runtime reads either variable now. The only remaining mention anywhere in the repo is the changelog entry recording their removal:

```
grep -rn "SEAMLESS_BOOTSTRAP_SECRET\|SEAMLESS_BOOTSTRAP_ENABLED" .
CHANGELOG.md:218
```

The effect was a container that refused to boot for no reason: an operator upgrading from a release that used the bootstrap flow still has `SEAMLESS_BOOTSTRAP_ENABLED=true` in their environment, and the entrypoint exits with `Environment variable SEAMLESS_BOOTSTRAP_SECRET is not set` until they supply a secret that has no effect on anything. The first admin is granted through `OWNER_EMAIL` now.

## Verification

`sh -n validateEnvs.sh` passes. The pre-commit hook ran lint, format, the full coverage suite, and the build, all green.

No behavior change for any deployment that is not setting the dead variable, and the only change for one that is, is that it now boots.
