### PR TITLE
ci: tag and publish the release automatically after the version PR merges

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -4,6 +4,12 @@ on:
   push:
     tags:
       - 'v*'
+  workflow_call:
+    inputs:
+      image_tag:
+        description: 'Tag to build and publish (e.g. v1.2.3)'
+        required: true
+        type: string
 
 permissions:
   contents: read
@@ -17,9 +23,16 @@ jobs:
   build-and-publish:
     runs-on: ubuntu-latest
 
+    env:
+      # On a tag push this is the ref (e.g. v1.2.3); when called from the
+      # version workflow it is the tag that release just created.
+      IMAGE_TAG: ${{ inputs.image_tag || github.ref_name }}
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.image_tag || github.ref_name }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -36,11 +49,10 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: |
-            ghcr.io/fells-code/seamless-auth-api
+            ghcr.io/${{ env.IMAGE_NAME }}
           tags: |
-            type=ref,event=tag
+            type=raw,value=${{ env.IMAGE_TAG }}
             type=raw,value=latest
-            type=raw,value=nightly,enable={{is_default_branch}}
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,9 @@ jobs:
     runs-on: ubuntu-latest
     env:
       HUSKY: 0
+    outputs:
+      new_tag: ${{ steps.tag.outputs.new_tag }}
+      version: ${{ steps.tag.outputs.version }}
 
     steps:
       - name: Checkout repo
@@ -40,6 +43,9 @@ jobs:
       - name: Lint
         run: npm run lint
 
+      - name: Check formatting
+        run: npm run format:check
+
       - name: Test
         run: npm run test:run
 
@@ -50,6 +56,7 @@ jobs:
         run: npm run build
 
       - name: Create or update version and changelog PR
+        id: changesets
         uses: changesets/action@v1
         with:
           version: npm run version-packages
@@ -57,3 +64,61 @@ jobs:
           commit: 'chore: update version and changelog'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # Once the version PR is merged there are no changesets left, so the
+      # version in package.json is the one to release. Tag it (idempotently) so
+      # a versioned image is published. The tag is created here rather than
+      # relying on the tag-push event because pushes made with GITHUB_TOKEN do
+      # not trigger other workflows; the image build is invoked directly below.
+      - name: Tag release
+        id: tag
+        if: steps.changesets.outputs.hasChangesets == 'false'
+        run: |
+          set -euo pipefail
+          VERSION="$(node -p "require('./package.json').version")"
+          TAG="v${VERSION}"
+          if git rev-parse -q --verify "refs/tags/${TAG}" >/dev/null; then
+            echo "Tag ${TAG} already exists; nothing to release."
+            echo "new_tag=false" >> "$GITHUB_OUTPUT"
+          else
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+            git tag "${TAG}"
+            git push origin "${TAG}"
+            echo "new_tag=true" >> "$GITHUB_OUTPUT"
+            echo "version=${TAG}" >> "$GITHUB_OUTPUT"
+          fi
+
+      # Publish a GitHub Release for the freshly created tag, using the notes
+      # changesets already wrote to CHANGELOG.md so the release body matches the
+      # changelog rather than a raw commit list.
+      - name: Create GitHub Release
+        if: steps.tag.outputs.new_tag == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          VERSION="$(node -p "require('./package.json').version")"
+          TAG="v${VERSION}"
+          awk -v header="## ${VERSION}" '
+            $0 == header { capture = 1; next }
+            capture && /^## / { exit }
+            capture { print }
+          ' CHANGELOG.md > release-notes.md
+          if [ -s release-notes.md ]; then
+            gh release create "${TAG}" --title "${TAG}" --notes-file release-notes.md
+          else
+            echo "No CHANGELOG section for ${VERSION}; using generated notes."
+            gh release create "${TAG}" --title "${TAG}" --generate-notes
+          fi
+
+  publish-image:
+    name: Publish versioned image
+    needs: version-changelog
+    if: needs.version-changelog.outputs.new_tag == 'true'
+    permissions:
+      contents: read
+      packages: write
+    uses: ./.github/workflows/docker-publish.yml
+    with:
+      image_tag: ${{ needs.version-changelog.outputs.version }}


### PR DESCRIPTION
## What

Closes the gap between merging the changesets version PR and having a published image. The version PR bumped `package.json` and `CHANGELOG.md`, but nothing tagged the result, so `docker-publish.yml` (which triggers on `v*` tags) only ran after the tag and GitHub Release were cut by hand.

`release.yml` now finishes the release itself. After the `changesets/action` step:

1. **Tag release**, gated on `hasChangesets == 'false'`, which is true exactly when the version PR has just merged. Reads the version from `package.json` and pushes `v<version>` if that tag does not already exist.
2. **Create GitHub Release**, extracting the matching `## <version>` section from `CHANGELOG.md` so the body is the changelog entry rather than a commit list, falling back to `--generate-notes` if the section is empty.
3. **publish-image**, which calls `docker-publish.yml` directly.

`docker-publish.yml` gains a `workflow_call` trigger with an `image_tag` input, checks that ref out, and derives `IMAGE_TAG` from `inputs.image_tag || github.ref_name` so both entry paths work.

## Why the image build is invoked directly

Pushes made with `GITHUB_TOKEN` deliberately do not trigger other workflows, so a tag pushed by CI would never have fired `docker-publish.yml` on its own. This mirrors what `seamless-terraform-service` does. There is no double build: the manual `push: tags` path still works for a tag pushed by hand.

Tagging is idempotent, so a commit to main carrying no changeset finds the tag already present and does nothing.

## Two changes beyond the core fix

- Dropped `type=raw,value=nightly,enable={{is_default_branch}}` from the image tags. It was dead on a tag-only trigger, where `is_default_branch` is always false, and once invoked from a push to main it would have mislabeled every release image as `nightly`. Nothing across the ecosystem repos references `seamless-auth-api:nightly`. `type=ref,event=tag` was also replaced with the raw `IMAGE_TAG`, since `event=tag` produces nothing on a `workflow_call`.
- Added `npm run format:check` to the release job. It was already in `ci.yml` but missing here, and the org baseline requires formatting to pass before a release.

## Verification

Both workflows parse as valid YAML and the job graph resolves (`version-changelog`, `publish-image`). The changelog extraction was run against the real `CHANGELOG.md` and produced the correct section. Local checks on the branch: lint clean, typecheck clean, `format:check` clean, 966 tests passing across 91 files.

Not verified end to end, since the tag and release path can only run for real on a merge to main.

## Note on existing drift

Tag `v0.7.3` currently sits on `7b8b6c2`, one commit ahead of the version commit `1b826de` that actually set `0.7.3`, and `.changeset/trust-proxy-client-address.md` is still pending on main. That fix will therefore be released again as `0.7.4`. The automation tags the version commit exactly, so this does not recur.

No changeset here, as this is CI only and not user facing.